### PR TITLE
Fix permission queue, workspace selection, and HTML preview sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,10 @@ Jelico protects users from destructive AI actions with an approval workflow.
 - "Allow All (This Session)" toggle with warning
 - View session permissions
 - View workspace permissions
+- Pending permission requests are queued in the main process and fetched by the renderer on startup to prevent missed prompts.
+
+**HTML Artifact Preview Safety:**
+- HTML previews run in a sandboxed iframe without `allow-same-origin` to prevent access to the parent app DOM.
 
 **Files:**
 - `electron/services/permissionChecker.ts` - Core permission checking

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -115,6 +115,7 @@ contextBridge.exposeInMainWorld('jelico', {
       action: string
       workspaceId?: string
     }) => ipcRenderer.invoke('permission:respond', data),
+    getPendingRequests: () => ipcRenderer.invoke('permission:getPending'),
     getAllowAll: () => ipcRenderer.invoke('permission:getAllowAll'),
     setAllowAll: (allow: boolean) => ipcRenderer.invoke('permission:setAllowAll', allow),
     getSessionPermissions: () => ipcRenderer.invoke('permission:getSessionPermissions'),

--- a/electron/services/permissionChecker.ts
+++ b/electron/services/permissionChecker.ts
@@ -12,6 +12,7 @@ export type ActionType = 'read' | 'write' | 'delete' | 'execute' | 'web' | 'spaw
 
 interface PendingRequest {
   id: string
+  request: PermissionRequest
   resolve: (result: { permission: PermissionAction; remembered: boolean }) => void
   reject: (error: Error) => void
 }
@@ -285,7 +286,7 @@ export async function requestPermission(
   return new Promise((resolve, reject) => {
     // No timeout - wait indefinitely for user response
     // Store pending request
-    pendingRequests.set(requestId, { id: requestId, resolve, reject })
+    pendingRequests.set(requestId, { id: requestId, request, resolve, reject })
 
     // Send to renderer
     mainWindow.webContents.send('permission:request', {
@@ -293,6 +294,15 @@ export async function requestPermission(
       ...request,
     })
   })
+}
+
+function getOldestPendingRequest(): (PermissionRequest & { requestId: string }) | null {
+  const pending = pendingRequests.values().next().value as PendingRequest | undefined
+  if (!pending) return null
+  return {
+    requestId: pending.id,
+    ...pending.request,
+  }
 }
 
 /**
@@ -398,6 +408,7 @@ ipcMain.handle('permission:setAllowAll', (_, allow: boolean) => {
   setAllowAllSession(allow)
   return { success: true }
 })
+ipcMain.handle('permission:getPending', () => getOldestPendingRequest())
 
 // Get session permissions
 ipcMain.handle('permission:getSessionPermissions', () => getSessionPermissions())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/Canvas/HtmlViewer.tsx
+++ b/src/components/Canvas/HtmlViewer.tsx
@@ -282,7 +282,7 @@ export function HtmlViewer({ html, isStreaming = false, onSave }: HtmlViewerProp
             key={refreshKey}
             srcDoc={sandboxedHtml}
             className="w-full h-full border-0 bg-white"
-            sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
+            sandbox="allow-scripts allow-forms allow-modals allow-popups"
             title="HTML Preview"
           />
         ) : view === 'diff' ? (

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,19 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.9.3',
+    date: '2026-02-04',
+    changes: {
+      fixed: [
+        'Queued permission requests now surface on renderer startup to prevent tool-call hangs',
+        'Workspace selection now updates the active conversation workspace so artifacts route correctly',
+      ],
+      security: [
+        'HTML artifact previews no longer use allow-same-origin, preventing access to the parent app DOM',
+      ],
+    },
+  },
+  {
     version: '0.9.2',
     date: '2026-02-03',
     changes: {

--- a/src/stores/permissions.ts
+++ b/src/stores/permissions.ts
@@ -212,6 +212,14 @@ export const usePermissionStore = create<PermissionStore>((set, get) => ({
     }
 
     set({ mainProcessRequest: null })
+    try {
+      const nextRequest = await window.jelico.permissions.getPendingRequests()
+      if (nextRequest && !get().mainProcessRequest) {
+        get().setMainProcessRequest(nextRequest)
+      }
+    } catch (error) {
+      console.error('Failed to load pending permission request:', error)
+    }
   },
 
   // Session settings
@@ -258,6 +266,16 @@ export const usePermissionStore = create<PermissionStore>((set, get) => ({
     const cleanup = window.jelico.permissions.onPermissionRequest((request) => {
       get().setMainProcessRequest(request)
     })
+    void (async () => {
+      try {
+        const pending = await window.jelico.permissions.getPendingRequests()
+        if (pending && !get().mainProcessRequest) {
+          get().setMainProcessRequest(pending)
+        }
+      } catch (error) {
+        console.error('Failed to load pending permission request:', error)
+      }
+    })()
     return cleanup
   },
 }))

--- a/src/stores/workspaces.ts
+++ b/src/stores/workspaces.ts
@@ -49,10 +49,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       if (workspace) {
         // Reload workspaces and set as active
         const workspaces = await window.jelico.workspaces.list()
-        set({
-          workspaces,
-          activeWorkspaceId: workspace.id,
-        })
+        set({ workspaces })
+        get().setActiveWorkspace(workspace.id)
         return workspace
       }
       return null

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -150,6 +150,7 @@ interface Window {
       request: (request: PermissionRequest) => Promise<PermissionRequestResult>
       // New permission checker methods
       respond: (data: PermissionRespondData) => Promise<{ success: boolean }>
+      getPendingRequests: () => Promise<MainProcessPermissionRequest | null>
       getAllowAll: () => Promise<boolean>
       setAllowAll: (allow: boolean) => Promise<{ success: boolean }>
       getSessionPermissions: () => Promise<Array<{ key: string; permission: PermissionAction }>>


### PR DESCRIPTION
Summary
- surface queued permission requests in the renderer so tool calls don’t stall waiting for user approval
- drive workspace selection through `setActiveWorkspace` so conversations and artifacts honor the chosen workspace directory
- tighten the HTML artifact iframe sandbox by removing `allow-same-origin` to keep artifact JS from touching the host UI

Testing
- Not run (not requested)