### PR TITLE
v0.9.4: macOS UI spacing, icon fixes, workspace transfer, tool-call repair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
Need to redeploy as we lost the fixes in the git pull for all future changes