### PR TITLE
v0.10.0: window gesture controls and selection guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.9.4
+**Current Version:** 0.10.0
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root

--- a/electron/ipc/window.ts
+++ b/electron/ipc/window.ts
@@ -1,0 +1,73 @@
+import { ipcMain, BrowserWindow } from 'electron'
+
+interface WindowDragState {
+  offsetX: number
+  offsetY: number
+}
+
+const dragStateByWebContents = new Map<number, WindowDragState>()
+
+export function registerWindowHandlers() {
+  ipcMain.handle('window:toggleMaximize', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win) {
+      return { success: false, error: 'No window' }
+    }
+
+    if (win.isFullScreen()) {
+      win.setFullScreen(false)
+      return { success: true, state: 'restored' }
+    }
+
+    if (win.isMaximized()) {
+      win.unmaximize()
+      return { success: true, state: 'restored' }
+    }
+
+    win.maximize()
+    return { success: true, state: 'maximized' }
+  })
+
+  ipcMain.handle('window:startDrag', (event, mouseScreenX: number, mouseScreenY: number) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win) {
+      return { success: false, error: 'No window' }
+    }
+
+    // Keep native maximize/fullscreen behavior predictable.
+    if (win.isMaximized() || win.isFullScreen()) {
+      return { success: false, error: 'Window is not movable in current state' }
+    }
+
+    const [winX, winY] = win.getPosition()
+    dragStateByWebContents.set(event.sender.id, {
+      offsetX: Math.round(mouseScreenX) - winX,
+      offsetY: Math.round(mouseScreenY) - winY,
+    })
+
+    return { success: true }
+  })
+
+  ipcMain.handle('window:updateDrag', (event, mouseScreenX: number, mouseScreenY: number) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win) {
+      return { success: false, error: 'No window' }
+    }
+
+    const dragState = dragStateByWebContents.get(event.sender.id)
+    if (!dragState) {
+      return { success: false, error: 'No active drag state' }
+    }
+
+    const nextX = Math.round(mouseScreenX) - dragState.offsetX
+    const nextY = Math.round(mouseScreenY) - dragState.offsetY
+    win.setPosition(nextX, nextY)
+
+    return { success: true }
+  })
+
+  ipcMain.handle('window:endDrag', (event) => {
+    dragStateByWebContents.delete(event.sender.id)
+    return { success: true }
+  })
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,7 @@ import { registerBackupHandlers } from './ipc/backup'
 import { registerSpeechHandlers } from './ipc/speech'
 import { registerCompactionHandlers } from './ipc/compaction'
 import { registerUpdateHandlers } from './ipc/updates'
+import { registerWindowHandlers } from './ipc/window'
 
 // Get version and git info
 const packageJson = require('../package.json')
@@ -315,6 +316,7 @@ app.whenReady().then(async () => {
   registerSpeechHandlers()
   registerCompactionHandlers()
   registerUpdateHandlers()
+  registerWindowHandlers()
 
   // Create window
   createWindow()

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -210,6 +210,12 @@ contextBridge.exposeInMainWorld('jelico', {
       return () => ipcRenderer.removeListener('updates:download-progress', handler)
     },
   },
+  window: {
+    toggleMaximize: () => ipcRenderer.invoke('window:toggleMaximize'),
+    startDrag: (mouseScreenX: number, mouseScreenY: number) => ipcRenderer.invoke('window:startDrag', mouseScreenX, mouseScreenY),
+    updateDrag: (mouseScreenX: number, mouseScreenY: number) => ipcRenderer.invoke('window:updateDrag', mouseScreenX, mouseScreenY),
+    endDrag: () => ipcRenderer.invoke('window:endDrag'),
+  },
   ai: {
     stream: (params: any) => {
       const channelId = crypto.randomUUID()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,33 @@ import { WelcomeScreen, type OnboardingProfile } from './components/Onboarding/W
 const DEFAULT_CANVAS_WIDTH = 500
 const MIN_CANVAS_WIDTH = 300
 const MAX_CANVAS_WIDTH = 800
+const WINDOW_DRAG_START_THRESHOLD = 2
+const INTERACTIVE_DOUBLE_CLICK_SELECTOR = [
+  'button',
+  'a',
+  'input',
+  'textarea',
+  'select',
+  'option',
+  'label',
+  '[role="button"]',
+  '[role="link"]',
+  '[contenteditable="true"]',
+  '[contenteditable="plaintext-only"]',
+  '[contenteditable=""]',
+  'iframe',
+  '.monaco-editor',
+  '.monaco-editor *',
+].join(',')
+
+interface WindowDragSession {
+  originScreenX: number
+  originScreenY: number
+  starting: boolean
+  started: boolean
+  onMouseMove: (event: MouseEvent) => void
+  onMouseUp: (event: MouseEvent) => void
+}
 
 export default function App() {
   const { providers, loadProviders, isLoading } = useProviderStore()
@@ -39,6 +66,13 @@ export default function App() {
   const [canvasWidth, setCanvasWidth] = useState(DEFAULT_CANVAS_WIDTH)
   const [isResizing, setIsResizing] = useState(false)
   const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const windowDragRef = useRef<WindowDragSession | null>(null)
+  const isInteractiveTarget = useCallback((target: HTMLElement | null) => {
+    if (!target) return false
+    if (target.closest('[data-resize-handle]')) return true
+    if (target.closest('[data-window-toggle="ignore"]')) return true
+    return Boolean(target.closest(INTERACTIVE_DOUBLE_CLICK_SELECTOR))
+  }, [])
 
   useEffect(() => {
     loadProviders()
@@ -68,6 +102,107 @@ export default function App() {
     checkForUpdates()
     return () => stopListening()
   }, [])
+
+  const stopWindowDrag = useCallback(() => {
+    const dragSession = windowDragRef.current
+    if (!dragSession) return
+
+    document.removeEventListener('mousemove', dragSession.onMouseMove)
+    document.removeEventListener('mouseup', dragSession.onMouseUp)
+    windowDragRef.current = null
+
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+
+    if (dragSession.started) {
+      window.jelico.window.endDrag().catch((error) => {
+        console.error('Failed to end window drag:', error)
+      })
+    }
+  }, [])
+
+  const handleAppMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return
+    if (event.detail > 1) return
+    if (isResizing) return
+
+    const target = event.target as HTMLElement | null
+    if (isInteractiveTarget(target)) return
+
+    stopWindowDrag()
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const dragSession = windowDragRef.current
+      if (!dragSession) return
+
+      if (!dragSession.started) {
+        const movedX = Math.abs(moveEvent.screenX - dragSession.originScreenX)
+        const movedY = Math.abs(moveEvent.screenY - dragSession.originScreenY)
+        if (movedX < WINDOW_DRAG_START_THRESHOLD && movedY < WINDOW_DRAG_START_THRESHOLD) {
+          return
+        }
+        if (dragSession.starting) return
+
+        dragSession.starting = true
+        window.jelico.window.startDrag(moveEvent.screenX, moveEvent.screenY)
+          .then((result) => {
+            const activeDragSession = windowDragRef.current
+            if (!activeDragSession) return
+
+            activeDragSession.starting = false
+            if (!result.success) {
+              stopWindowDrag()
+              return
+            }
+
+            activeDragSession.started = true
+            document.body.style.userSelect = 'none'
+            document.body.style.cursor = 'move'
+
+            return window.jelico.window.updateDrag(moveEvent.screenX, moveEvent.screenY)
+          })
+          .catch((error) => {
+            console.error('Failed to start window drag:', error)
+            stopWindowDrag()
+          })
+        return
+      }
+
+      window.jelico.window.updateDrag(moveEvent.screenX, moveEvent.screenY).catch((error) => {
+        console.error('Failed to update window drag:', error)
+        stopWindowDrag()
+      })
+    }
+
+    const onMouseUp = () => {
+      stopWindowDrag()
+    }
+
+    windowDragRef.current = {
+      originScreenX: event.screenX,
+      originScreenY: event.screenY,
+      starting: false,
+      started: false,
+      onMouseMove,
+      onMouseUp,
+    }
+
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+  }, [isInteractiveTarget, isResizing, stopWindowDrag])
+
+  useEffect(() => {
+    return () => stopWindowDrag()
+  }, [stopWindowDrag])
+
+  const handleAppDoubleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (isResizing) return
+    const target = event.target as HTMLElement | null
+    if (isInteractiveTarget(target)) return
+    window.jelico.window.toggleMaximize().catch((error) => {
+      console.error('Failed to toggle window maximize:', error)
+    })
+  }, [isResizing, isInteractiveTarget])
 
   // Handle resize drag
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
@@ -154,8 +289,12 @@ export default function App() {
   // Hide header when in new chat view (no conversation or empty conversation)
   const showNewChatUI = !activeConversationId || (messages.length === 0 && !isStreaming)
 
-  return (
-    <div className="h-screen flex bg-bg-void text-text-primary overflow-hidden relative">
+    return (
+    <div
+      className="h-screen flex bg-bg-void text-text-primary overflow-hidden relative select-none"
+      onDoubleClick={handleAppDoubleClick}
+      onMouseDown={handleAppMouseDown}
+    >
       {/* Floating sidebar toggle button at left edge */}
       <button
         onClick={toggleSidebar}
@@ -193,11 +332,15 @@ export default function App() {
                 className={`w-1 cursor-col-resize hover:bg-accent/50 transition-colors flex-shrink-0 ${
                   isResizing ? 'bg-accent' : 'bg-transparent hover:bg-border'
                 }`}
+                data-resize-handle
                 onMouseDown={handleResizeStart}
                 title="Drag to resize"
               />
               {/* Canvas panel with dynamic width */}
-              <div style={{ width: canvasWidth }} className="flex-shrink-0">
+              <div
+                style={{ width: canvasWidth }}
+                className={`flex-shrink-0 ${isResizing ? 'pointer-events-none' : ''}`}
+              >
                 <CanvasPanel />
               </div>
             </>

--- a/src/components/Chat/ChatArea.tsx
+++ b/src/components/Chat/ChatArea.tsx
@@ -80,7 +80,7 @@ export function ChatArea() {
   // New chat / Welcome UI - centered stack
   if (showNewChatUI) {
     return (
-      <div className="flex-1 flex flex-col min-h-0">
+      <div className="flex-1 flex flex-col min-h-0" data-window-toggle="ignore">
         <div className="flex-1 flex items-center justify-center p-6">
           <div className="w-full max-w-xl">
             <NewChatView
@@ -95,9 +95,9 @@ export function ChatArea() {
 
   // Active conversation UI - normal chat layout
   return (
-    <div className="flex-1 flex flex-col min-h-0">
+    <div className="flex-1 flex flex-col min-h-0" data-window-toggle="ignore">
       {/* Messages area */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto select-text">
         <div className="max-w-3xl mx-auto py-6 px-4">
           <MessageList
             messages={messages}

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -458,7 +458,7 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
           }
           disabled={disabled}
           rows={centered ? 4 : 1}
-          className={`flex-1 bg-transparent text-text-primary placeholder:text-text-muted outline-none resize-none disabled:cursor-not-allowed focus:outline-none focus:ring-0 border-none leading-6 p-3 pb-0 ${
+          className={`flex-1 bg-transparent text-text-primary placeholder:text-text-muted outline-none resize-none disabled:cursor-not-allowed focus:outline-none focus:ring-0 border-none leading-6 p-3 pb-0 select-text ${
             centered ? 'min-h-[96px] max-h-[200px]' : 'min-h-[24px] max-h-[150px]'
           }`}
         />

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,21 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.10.0',
+    date: '2026-02-05',
+    changes: {
+      added: [
+        'Double-click on non-interactive app surfaces now toggles the window between maximized and restored states',
+        'Click-hold and drag on non-interactive app surfaces now repositions the window',
+      ],
+      fixed: [
+        'Canvas divider drag now stays responsive when cursor passes over preview content such as iframes',
+        'Sidebar and header text no longer gets accidentally selected during window drag/maximize interactions',
+        'Chat area now ignores window drag/maximize gestures so text selection behaves normally in conversation content',
+      ],
+    },
+  },
+  {
     version: '0.9.4',
     date: '2026-02-04',
     changes: {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -64,6 +64,12 @@ interface Window {
       openRelease: (url: string) => Promise<boolean>
       onDownloadProgress: (callback: (progress: UpdateDownloadProgress) => void) => () => void
     }
+    window: {
+      toggleMaximize: () => Promise<{ success: boolean; state?: 'maximized' | 'restored'; error?: string }>
+      startDrag: (mouseScreenX: number, mouseScreenY: number) => Promise<{ success: boolean; error?: string }>
+      updateDrag: (mouseScreenX: number, mouseScreenY: number) => Promise<{ success: boolean; error?: string }>
+      endDrag: () => Promise<{ success: boolean; error?: string }>
+    }
     ai: {
       stream: (params: StreamParams) => string
       onStreamChunk: (channelId: string, callback: (chunk: string) => void) => void


### PR DESCRIPTION
## Summary
This release adds desktop window gesture controls while preventing accidental text selection and drag conflicts in the UI chrome.

## Changes
- added IPC window handlers for maximize/restore toggle and window drag lifecycle
- enabled double-click maximize/restore on non-interactive surfaces
- enabled click-hold window repositioning on non-interactive surfaces
- disabled text selection by default at app root, with explicit opt-in for chat transcript and prompt textarea
- excluded the entire chat surface from window gesture handling to preserve normal text selection behavior
- improved canvas resize stability by blocking canvas pointer events during divider drag
- updated `AGENTS.md` current version to `0.10.0`
- updated changelog entry for `0.10.0`

## Validation
- manual verification of maximize/restore toggle via double-click
- manual verification of window reposition via click-hold drag
- manual verification that chat selection does not trigger window gestures
- `npx tsc --noEmit`

## Release Notes (v0.10.0)
### Added
- Double-click on non-interactive app surfaces now toggles the window between maximized and restored states
- Click-hold and drag on non-interactive app surfaces now repositions the window

### Fixed
- Canvas divider drag now stays responsive when cursor passes over preview content such as iframes
- Sidebar and header text no longer gets accidentally selected during window drag/maximize interactions
- Chat area now ignores window drag/maximize gestures so text selection behaves normally in conversation content

Fixes #12
