### PR TITLE
v0.10.1: circular context indicator and persistent context usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.10.0
+**Current Version:** 0.10.1
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root

--- a/electron/ipc/conversations.ts
+++ b/electron/ipc/conversations.ts
@@ -24,6 +24,7 @@ function toMessageApi(row: any) {
     toolCalls: row.tool_calls,
     toolResults: row.tool_results,
     attachments: row.attachments,
+    usage: row.usage,
     createdAt: row.created_at,
   }
 }
@@ -60,8 +61,14 @@ export function registerConversationHandlers() {
       toolCalls: messageInput.toolCalls,
       toolResults: messageInput.toolResults,
       attachments: messageInput.attachments,
+      usage: messageInput.usage,
     })
     return toMessageApi(message)
+  })
+
+  // Delete a message from a conversation
+  ipcMain.handle('conversations:deleteMessage', async (_, messageId: string) => {
+    return { success: messageDb.delete(messageId) }
   })
 
   // Update a message (for adding tool calls/results)
@@ -71,6 +78,7 @@ export function registerConversationHandlers() {
       toolCalls: updates.toolCalls,
       toolResults: updates.toolResults,
       attachments: updates.attachments,
+      usage: updates.usage,
     })
     return message ? toMessageApi(message) : null
   })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -24,10 +24,13 @@ contextBridge.exposeInMainWorld('jelico', {
     get: (id: string) => ipcRenderer.invoke('conversations:get', id),
     create: (conversation: any) => ipcRenderer.invoke('conversations:create', conversation),
     addMessage: (convId: string, message: any) => ipcRenderer.invoke('conversations:addMessage', convId, message),
+    deleteMessage: (messageId: string) => ipcRenderer.invoke('conversations:deleteMessage', messageId),
     updateMessage: (messageId: string, updates: any) => ipcRenderer.invoke('conversations:updateMessage', messageId, updates),
     updateTitle: (id: string, title: string) => ipcRenderer.invoke('conversations:updateTitle', id, title),
-    updateWorkspaceId: (id: string, workspaceId: string | null) => ipcRenderer.invoke('conversations:updateWorkspaceId', id, workspaceId),
-    transferToWorkspace: (id: string, workspaceId: string | null) => ipcRenderer.invoke('conversations:transferToWorkspace', id, workspaceId),
+    updateWorkspaceId: (id: string, workspaceId: string | null) =>
+      ipcRenderer.invoke('conversations:updateWorkspaceId', id, workspaceId),
+    transferToWorkspace: (id: string, workspaceId: string | null) =>
+      ipcRenderer.invoke('conversations:transferToWorkspace', id, workspaceId),
     getArtifactCount: (id: string) => ipcRenderer.invoke('conversations:getArtifactCount', id),
     delete: (id: string) => ipcRenderer.invoke('conversations:delete', id),
   },

--- a/electron/services/database.ts
+++ b/electron/services/database.ts
@@ -507,6 +507,7 @@ export const messageDb = {
       tool_calls: message.toolCalls,
       tool_results: message.toolResults,
       attachments: message.attachments,
+      usage: message.usage,
       created_at: now,
     }
 
@@ -528,9 +529,23 @@ export const messageDb = {
     if (updates.toolCalls !== undefined) message.tool_calls = updates.toolCalls
     if (updates.toolResults !== undefined) message.tool_results = updates.toolResults
     if (updates.attachments !== undefined) message.attachments = updates.attachments
+    if (updates.usage !== undefined) message.usage = updates.usage
 
     saveDb()
     return message
+  },
+
+  delete(id: string): boolean {
+    const index = db.messages.findIndex(m => m.id === id)
+    if (index === -1) return false
+
+    const conversationId = db.messages[index].conversation_id
+    db.messages.splice(index, 1)
+
+    // Keep conversation ordering fresh after message deletion.
+    conversationDb.touch(conversationId)
+    saveDb()
+    return true
   },
 
   getByConversation(conversationId: string): MessageRow[] {
@@ -598,6 +613,14 @@ interface MessageAttachment {
   data: string // base64 for images, text content for text files
 }
 
+interface MessageUsageRow {
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  tokensPerSecond?: number
+  durationMs?: number
+}
+
 interface MessageRow {
   id: string
   conversation_id: string
@@ -606,6 +629,7 @@ interface MessageRow {
   tool_calls?: ToolCallRow[]
   tool_results?: ToolResultRow[]
   attachments?: MessageAttachment[]
+  usage?: MessageUsageRow
   created_at: number
 }
 
@@ -615,6 +639,7 @@ interface MessageInput {
   toolCalls?: ToolCallRow[]
   toolResults?: ToolResultRow[]
   attachments?: MessageAttachment[]
+  usage?: MessageUsageRow
 }
 
 interface WorkspaceRow {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/Layout/ContextIndicator.tsx
+++ b/src/components/Layout/ContextIndicator.tsx
@@ -1,21 +1,21 @@
 /**
  * ContextIndicator - Shows context window usage in header
  *
- * Displays percentage, expands to show progress bar when clicked.
+ * Displays a circle indicator and toggles percentage text when clicked.
  * Only visible when there's an active conversation with messages.
  */
 
-import { useState } from 'react'
 import { Loader2, AlertTriangle } from 'lucide-react'
 import { useChatStore } from '../../stores/chat'
 import { useContextStore } from '../../stores/context'
 import { useProviderStore } from '../../stores/providers'
+import { useUIStore } from '../../stores/ui'
 
 export function ContextIndicator() {
-  const [showBar, setShowBar] = useState(false)
   const { activeConversationId, messages, isStreaming } = useChatStore()
   const { getContextUsage, isCompacting } = useContextStore()
   const { activeModel } = useProviderStore()
+  const { showContextText, toggleContextText } = useUIStore()
 
   // Get context usage for current conversation
   const contextUsage = activeConversationId ? getContextUsage(activeConversationId) : null
@@ -27,22 +27,30 @@ export function ContextIndicator() {
   }
 
   const percentage = Math.round(contextUsage.percentage * 100)
+  const circleSize = 18
+  const progressStrokeWidth = 2
+  const trackStrokeWidth = 1.05
+  const radius = (circleSize - progressStrokeWidth) / 2
+  const circumference = 2 * Math.PI * radius
+  const progress = Math.min(Math.max(contextUsage.percentage, 0), 1)
+  const dashOffset = circumference * (1 - progress)
+  const trackDashPattern = '0.22 1.7'
 
   return (
     <div className="flex items-center gap-2">
-      {/* Percentage button */}
+      {/* Circle indicator button */}
       <button
-        onClick={() => setShowBar(!showBar)}
+        onClick={toggleContextText}
         className={`
-          flex items-center gap-1.5 px-2 py-1 rounded text-xs font-mono
+          flex items-center gap-1.5 px-2 py-1 rounded text-xs
           transition-colors
           ${contextUsage.shouldWarn
             ? 'text-warning hover:bg-warning/10'
             : 'text-text-muted hover:text-text-secondary hover:bg-bg-surface'}
         `}
-        title={showBar
-          ? `Context window of ${activeModel || 'model'}, click to hide bar`
-          : `Context window of ${activeModel || 'model'}, click to see bar`}
+        title={showContextText
+          ? `Context window of ${activeModel || 'model'} (${percentage}%), click to hide percentage`
+          : `Context window of ${activeModel || 'model'} (${percentage}%), click to show percentage`}
       >
         {/* Spinner during compaction */}
         {isCompacting && (
@@ -52,19 +60,45 @@ export function ContextIndicator() {
         {!isCompacting && contextUsage.shouldWarn && (
           <AlertTriangle className="w-3 h-3" />
         )}
-        <span>{percentage}%</span>
+        <svg
+          width={circleSize}
+          height={circleSize}
+          viewBox={`0 0 ${circleSize} ${circleSize}`}
+          className="-rotate-90"
+          aria-hidden="true"
+        >
+          <circle
+            cx={circleSize / 2}
+            cy={circleSize / 2}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={trackStrokeWidth}
+            strokeDasharray={trackDashPattern}
+            strokeLinecap="round"
+            className="text-text-muted"
+            style={{ opacity: 0.24 }}
+          />
+          <circle
+            cx={circleSize / 2}
+            cy={circleSize / 2}
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={progressStrokeWidth}
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+            strokeLinecap="round"
+            className="text-accent"
+          />
+        </svg>
       </button>
 
-      {/* Progress bar - shows when expanded */}
-      {showBar && (
-        <div className="w-40 h-2.5 bg-bg-void rounded-full overflow-hidden border border-border/30">
-          <div
-            className={`h-full transition-all duration-300 ${
-              contextUsage.shouldWarn ? 'bg-warning' : 'bg-accent'
-            }`}
-            style={{ width: `${Math.max(Math.min(percentage, 100), 1)}%` }}
-          />
-        </div>
+      {/* Percentage text - toggles on circle click */}
+      {showContextText && (
+        <span className="text-sm text-text-secondary">
+          Context: {percentage}%
+        </span>
       )}
     </div>
   )

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,21 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.10.1',
+    date: '2026-02-05',
+    changes: {
+      changed: [
+        'Header context indicator now uses a circular meter with a subtle dotted ghost ring and accent progress arc',
+        'Clicking the context ring now toggles inline "Context: XX%" text, and this visibility preference is remembered globally',
+      ],
+      fixed: [
+        'Conversation context usage now restores after app restart/update instead of resetting to 0%',
+        'Message usage stats are now persisted so context restoration uses actual token data when available',
+        'Regenerating the last response now removes the replaced assistant message from storage to keep persisted context accurate',
+      ],
+    },
+  },
+  {
     version: '0.10.0',
     date: '2026-02-05',
     changes: {

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -4,7 +4,7 @@ import { useArtifactStore } from './artifacts'
 import { useWorkspaceStore } from './workspaces'
 import { useAgentStore } from './agents'
 import { useSkillStore } from './skills'
-import { useContextStore } from './context'
+import { useContextStore, estimateTokens } from './context'
 import { useSandboxStore } from './sandbox'
 import { useTodoStore } from './todos'
 
@@ -150,6 +150,22 @@ interface ChatStore {
 let currentStreamChannelId: string | null = null
 let modeTransitionTimeoutId: ReturnType<typeof setTimeout> | null = null
 
+function getRestoredTokenCount(messages: Message[]): number {
+  if (messages.length === 0) return 0
+
+  // Prefer provider-reported totals from the most recent assistant message.
+  const latestUsage = [...messages]
+    .reverse()
+    .find((msg) => msg.role === 'assistant' && typeof msg.usage?.totalTokens === 'number' && msg.usage.totalTokens > 0)
+
+  if (latestUsage?.usage?.totalTokens) {
+    return latestUsage.usage.totalTokens
+  }
+
+  // Fallback for legacy conversations created before usage persistence.
+  return messages.reduce((sum, msg) => sum + estimateTokens(msg.content || ''), 0)
+}
+
 export const useChatStore = create<ChatStore>((set, get) => ({
   conversations: [],
   activeConversationId: null,
@@ -246,9 +262,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set({ isLoading: true })
     try {
       const conversation = await window.jelico.conversations.get(id)
+      const loadedMessages = conversation?.messages || []
+
       set({
         activeConversationId: id,
-        messages: conversation?.messages || [],
+        messages: loadedMessages,
         isLoading: false,
         // Clear streaming state when switching to prevent old stream data appearing
         isStreaming: false,
@@ -263,6 +281,24 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         isReasoning: false,
         reasoningContent: '',
       })
+
+      // Ensure context usage survives conversation reloads.
+      if (conversation) {
+        const contextState = useContextStore.getState()
+        const existing = contextState.conversationContexts[id]
+
+        if (!existing) {
+          await contextState.initConversationContext(id, conversation.providerId, conversation.model)
+        }
+
+        const shouldHydrate = !existing || existing.currentTokenCount === 0
+        if (shouldHydrate) {
+          const restoredTokenCount = getRestoredTokenCount(loadedMessages)
+          if (restoredTokenCount > 0) {
+            contextState.updateTokenCount(id, restoredTokenCount)
+          }
+        }
+      }
 
       // Restore workspace associated with this conversation (or reset to Sandbox if none)
       // Pass skipDbUpdate=true since we're restoring from DB, not changing
@@ -735,6 +771,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           content: fullContent || '(Used tools)', // Ensure non-empty for DB
           toolCalls: streamingToolCalls.length > 0 ? streamingToolCalls : undefined,
           toolResults: streamingToolResults.length > 0 ? streamingToolResults : undefined,
+          usage,
         })
 
         // Attach usage to the message object for display
@@ -1081,9 +1118,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     const messagesWithoutLast = messages.slice(0, lastAssistantIndex)
     set({ messages: messagesWithoutLast })
 
-    // Note: Old assistant message stays in DB (no deleteMessage API yet)
-    // This is fine - new message replaces it in UI, and conversation reload works correctly
-    // because we load messages by conversation and the new response overwrites conceptually
+    // Keep DB aligned with the UI so reloads don't resurrect regenerated responses.
+    try {
+      await window.jelico.conversations.deleteMessage(messages[lastAssistantIndex].id)
+    } catch (error) {
+      console.error('[Chat Store] Failed to delete regenerated assistant message from DB:', error)
+    }
 
     // Start streaming with existing messages (don't re-add user message)
     // The _isRegenerate flag tells sendMessage to skip adding user message

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -4,6 +4,7 @@ type SettingsTab = 'general' | 'providers' | 'skills' | 'backup'
 
 interface UIStore {
   sidebarCollapsed: boolean
+  showContextText: boolean
   settingsOpen: boolean
   settingsTab: SettingsTab
   providerSetupOpen: boolean
@@ -18,6 +19,8 @@ interface UIStore {
   onboardingStep: number
 
   toggleSidebar: () => void
+  toggleContextText: () => void
+  setShowContextText: (show: boolean) => void
   openSettings: (tab?: SettingsTab) => void
   closeSettings: () => void
   setSettingsTab: (tab: SettingsTab) => void
@@ -42,8 +45,14 @@ const getInitialOnboardingState = (): boolean => {
   return stored === 'true'
 }
 
+const getInitialContextTextState = (): boolean => {
+  const stored = localStorage.getItem('jelico:showContextText')
+  return stored === 'true'
+}
+
 export const useUIStore = create<UIStore>((set) => ({
   sidebarCollapsed: false,
+  showContextText: getInitialContextTextState(),
   settingsOpen: false,
   settingsTab: 'general',
   providerSetupOpen: false,
@@ -58,6 +67,15 @@ export const useUIStore = create<UIStore>((set) => ({
   onboardingStep: 0,
 
   toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
+  toggleContextText: () => set((state) => {
+    const next = !state.showContextText
+    localStorage.setItem('jelico:showContextText', String(next))
+    return { showContextText: next }
+  }),
+  setShowContextText: (show) => {
+    localStorage.setItem('jelico:showContextText', String(show))
+    set({ showContextText: show })
+  },
 
   openSettings: (tab = 'general') => set({ settingsOpen: true, settingsTab: tab }),
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -22,6 +22,7 @@ interface Window {
       get: (id: string) => Promise<Conversation | null>
       create: (conversation: ConversationInput) => Promise<Conversation>
       addMessage: (convId: string, message: MessageInput) => Promise<Message>
+      deleteMessage: (messageId: string) => Promise<{ success: boolean }>
       updateMessage: (messageId: string, updates: Partial<MessageInput>) => Promise<Message | null>
       updateTitle: (id: string, title: string) => Promise<void>
       updateWorkspaceId: (id: string, workspaceId: string | null) => Promise<Conversation | null>
@@ -249,6 +250,7 @@ interface Message {
   attachments?: MessageAttachmentData[]
   toolCalls?: ToolCallEvent[]
   toolResults?: ToolResultEvent[]
+  usage?: MessageUsageData
   createdAt: number
 }
 
@@ -266,6 +268,15 @@ interface MessageInput {
   toolCalls?: ToolCallEvent[]
   toolResults?: ToolResultEvent[]
   attachments?: MessageAttachmentData[]
+  usage?: MessageUsageData
+}
+
+interface MessageUsageData {
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  tokensPerSecond?: number
+  durationMs?: number
 }
 
 interface StreamParams {


### PR DESCRIPTION
## Summary
This PR introduces the new circular context indicator in the header and fixes context-usage persistence so usage survives reloads, restarts, updates, and regenerate flows.

## What Changed
- Replaced the old context percentage + progress bar combo with a circular meter.
- Added a dotted ghost background ring with an accent progress arc to make used vs available context visually distinct.
- Changed the interaction so clicking the ring toggles inline text: `Context: XX%`.
- Persisted the context text visibility toggle globally, so the preference follows conversation switching.
- Persisted assistant `usage` payloads into conversation message storage.
- Restored conversation token usage from persisted message usage when reopening conversations.
- Added fallback token estimation for older conversations that predate usage persistence.
- Added `conversations:deleteMessage` and used it during regenerate so replaced assistant messages are removed from storage.

## Why This Matters
- Context usage no longer appears to "reset to 0%" after app restart or update.
- Regenerate behavior is now storage-consistent, so persisted context data tracks the visible conversation more accurately.
- Header context UI is cleaner and gives a faster signal of usage while keeping optional text details one click away.

## Files of Interest
- `src/components/Layout/ContextIndicator.tsx`
- `src/stores/ui.ts`
- `src/stores/chat.ts`
- `electron/services/database.ts`
- `electron/ipc/conversations.ts`
- `electron/preload.ts`
- `src/vite-env.d.ts`
- `src/data/changelog.ts`
- `AGENTS.md`

## Validation
- `npm run build`
- `npx tsc --noEmit`

## Versioning
- Version bumped from `0.10.0` to `0.10.1`.
- Changelog entry added at the top of `src/data/changelog.ts`.
- Tag pushed: `v0.10.1`.

Fixes: none (no existing tracked issue for this scope)
