### PR TITLE
v0.11.0: improve artifact testing and chat turn reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.10.1
+**Current Version:** 0.11.0
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root

--- a/electron/ipc/ai.ts
+++ b/electron/ipc/ai.ts
@@ -40,6 +40,17 @@ import {
   writeSandboxFile,
   listSandboxFiles,
 } from '../services/sandbox'
+import {
+  openArtifactTestSession,
+  closeArtifactTestSession,
+  listArtifactTestSessions,
+  artifactTestClick,
+  artifactTestType,
+  artifactTestEvaluate,
+  artifactTestExtract,
+  artifactTestWaitFor,
+  artifactTestScreenshot,
+} from '../services/artifactTester'
 
 // Start orphan cleanup on module load
 startOrphanCleanup()
@@ -60,10 +71,6 @@ const pendingClarifications = new Map<string, PendingClarification>()
 
 // Debug flag - controlled by environment
 const DEBUG_API_REQUESTS = process.env.DEBUG_AI === 'true' || process.env.NODE_ENV === 'development'
-
-// Store accumulated tool input by toolCallId - needed because some providers stream args
-// via tool-input-delta but don't populate the final tool-call args (SDK bug workaround)
-const accumulatedToolInputByCallId = new Map<string, string>()
 
 // Stream timeouts - DISABLED (set to 0 to disable)
 // In the age of long-running agents, arbitrary timeouts cause more problems than they solve.
@@ -301,6 +308,7 @@ function getBuiltInTools(
     providerId: string
     model: string
     workspacePath?: string
+    conversationId?: string
     resetActivityTimeout?: () => void  // Allows blocking tools to keep stream alive
   },
   toolTracker: Map<string, ToolExecution>,
@@ -883,7 +891,9 @@ Types:
 - svg: SVG graphics
 - mermaid: Mermaid diagram syntax
 
-IMPORTANT: You MUST provide all required parameters (type, title, content). Do not call this tool with empty arguments.`,
+IMPORTANT: You MUST provide all required parameters (type, title, content). Do not call this tool with empty arguments.
+
+For type="html": after creating it, self-test with artifact_test before claiming it works (unless user explicitly says skip testing).`,
     parameters: z.object({
       type: z.enum(['code', 'document', 'html', 'svg', 'mermaid']).describe('The type of artifact'),
       title: z.string().min(1).describe('A short, descriptive title'),
@@ -925,7 +935,9 @@ IMPORTANT: You MUST provide all required parameters (type, title, content). Do n
       }
       return {
         success: true,
-        message: `Artifact "${title}" created successfully`,
+        message: type === 'html'
+          ? `Artifact "${title}" created successfully. Next step required: run artifact_test and verify behavior before claiming success.`
+          : `Artifact "${title}" created successfully`,
         warnings: validation.warnings.length > 0 ? validation.warnings : undefined,
       }
     },
@@ -938,7 +950,9 @@ IMPORTANT: You MUST provide all required parameters (type, title, content). Do n
 Use this to modify, improve, or fix content in an artifact that already exists.
 You must know the artifact ID from the existing artifacts context.
 
-IMPORTANT: You MUST provide id, type, and content parameters. Do not call this tool with empty arguments.`,
+IMPORTANT: You MUST provide id, type, and content parameters. Do not call this tool with empty arguments.
+
+For type="html": after updating it, self-test with artifact_test before claiming the fix works (unless user explicitly says skip testing).`,
     parameters: z.object({
       id: z.string().min(1).describe('The ID of the artifact to update'),
       type: z.enum(['code', 'document', 'html', 'svg', 'mermaid']).describe('The type of artifact (needed for validation)'),
@@ -981,8 +995,172 @@ IMPORTANT: You MUST provide id, type, and content parameters. Do not call this t
       }
       return {
         success: true,
-        message: `Artifact "${id}" updated successfully`,
+        message: type === 'html'
+          ? `Artifact "${id}" updated successfully. Next step required: run artifact_test and verify behavior before claiming success.`
+          : `Artifact "${id}" updated successfully`,
         warnings: validation.warnings.length > 0 ? validation.warnings : undefined,
+      }
+    },
+  })
+
+  // Artifact test tool - lets AI open and interact with HTML artifacts for verification.
+  tools.artifact_test = tool({
+    description: `Open and test HTML artifacts in a hidden browser session.
+Use this to verify artifact behavior (click buttons, type input, wait for updates, evaluate JS, capture screenshots).
+When user requirements are given, test each requirement explicitly before claiming success.
+
+Actions:
+- open: Open a test session from artifact_id (latest revision) or raw html
+- list_sessions: List active test sessions
+- click: Click element by CSS selector and verify observable change by default
+- type: Type into input/textarea/contenteditable
+- evaluate: Run JavaScript and return result
+- extract: Read text/html from page or selector
+- wait_for: Wait until text and/or selector appears
+- screenshot: Capture PNG screenshot path
+- close: Close a test session
+
+Notes:
+- open with artifact_id always targets latest revision of that artifact's base.
+- A click should be treated as failed if no observable UI change occurs (unless expect_change=false).
+- These sessions are isolated and hidden from users.`,
+    parameters: z.object({
+      action: z.enum([
+        'open',
+        'list_sessions',
+        'click',
+        'type',
+        'evaluate',
+        'extract',
+        'wait_for',
+        'screenshot',
+        'close',
+      ]).describe('Artifact test action to run'),
+      session_id: z.string().optional().describe('Session ID for actions after open'),
+      artifact_id: z.string().optional().describe('Artifact ID (for open action)'),
+      html: z.string().optional().describe('Raw HTML content (for open action when no artifact_id)'),
+      selector: z.string().optional().describe('CSS selector for click/type/extract/wait_for'),
+      text: z.string().optional().describe('Text content for type or wait_for'),
+      append: z.boolean().optional().describe('When typing, append to existing content (default false)'),
+      expect_change: z.boolean().optional().describe('For click: require observable UI change (default true)'),
+      wait_after_ms: z.number().int().min(0).max(5000).optional().describe('For click: wait before checking observable change (default 300ms)'),
+      expression: z.string().optional().describe('JavaScript expression for evaluate'),
+      timeout_ms: z.number().int().min(250).max(60000).optional().describe('Timeout for wait_for in ms'),
+      width: z.number().int().min(320).max(2560).optional().describe('Viewport width for open'),
+      height: z.number().int().min(240).max(1600).optional().describe('Viewport height for open'),
+    }).passthrough(),
+    execute: async (args) => {
+      try {
+        const normalizedArgs = {
+          action: args.action,
+          session_id: args.session_id ?? (args as any).sessionId,
+          artifact_id: args.artifact_id ?? (args as any).artifactId,
+          html: args.html,
+          selector: args.selector,
+          text: args.text,
+          append: args.append,
+          expect_change: args.expect_change ?? (args as any).expectChange,
+          wait_after_ms: args.wait_after_ms ?? (args as any).waitAfterMs,
+          expression: args.expression,
+          timeout_ms: args.timeout_ms ?? (args as any).timeoutMs,
+          width: args.width,
+          height: args.height,
+        }
+
+        switch (normalizedArgs.action) {
+          case 'open': {
+            if (!normalizedArgs.artifact_id && !normalizedArgs.html) {
+              return {
+                success: false,
+                error: 'open action requires artifact_id or html',
+              }
+            }
+            const result = await openArtifactTestSession({
+              artifactId: normalizedArgs.artifact_id,
+              html: normalizedArgs.html,
+              width: normalizedArgs.width,
+              height: normalizedArgs.height,
+            })
+            return { success: true, ...result }
+          }
+
+          case 'list_sessions': {
+            return {
+              success: true,
+              sessions: listArtifactTestSessions(),
+            }
+          }
+
+          case 'click': {
+            if (!normalizedArgs.session_id || !normalizedArgs.selector) {
+              return { success: false, error: 'click action requires session_id and selector' }
+            }
+            return await artifactTestClick(
+              normalizedArgs.session_id,
+              normalizedArgs.selector,
+              normalizedArgs.expect_change ?? true,
+              normalizedArgs.wait_after_ms ?? 300
+            )
+          }
+
+          case 'type': {
+            if (!normalizedArgs.session_id || !normalizedArgs.selector || normalizedArgs.text === undefined) {
+              return { success: false, error: 'type action requires session_id, selector, and text' }
+            }
+            return await artifactTestType(normalizedArgs.session_id, normalizedArgs.selector, normalizedArgs.text, !!normalizedArgs.append)
+          }
+
+          case 'evaluate': {
+            if (!normalizedArgs.session_id || !normalizedArgs.expression) {
+              return { success: false, error: 'evaluate action requires session_id and expression' }
+            }
+            return await artifactTestEvaluate(normalizedArgs.session_id, normalizedArgs.expression)
+          }
+
+          case 'extract': {
+            if (!normalizedArgs.session_id) {
+              return { success: false, error: 'extract action requires session_id' }
+            }
+            return await artifactTestExtract(normalizedArgs.session_id, normalizedArgs.selector)
+          }
+
+          case 'wait_for': {
+            if (!normalizedArgs.session_id) {
+              return { success: false, error: 'wait_for action requires session_id' }
+            }
+            return await artifactTestWaitFor({
+              sessionId: normalizedArgs.session_id,
+              text: normalizedArgs.text,
+              selector: normalizedArgs.selector,
+              timeoutMs: normalizedArgs.timeout_ms,
+            })
+          }
+
+          case 'screenshot': {
+            if (!normalizedArgs.session_id) {
+              return { success: false, error: 'screenshot action requires session_id' }
+            }
+            return await artifactTestScreenshot(normalizedArgs.session_id)
+          }
+
+          case 'close': {
+            if (!normalizedArgs.session_id) {
+              return { success: false, error: 'close action requires session_id' }
+            }
+            return await closeArtifactTestSession(normalizedArgs.session_id)
+          }
+
+          default:
+            return {
+              success: false,
+              error: `Unknown artifact_test action: ${(normalizedArgs as any).action}`,
+            }
+        }
+      } catch (error: any) {
+        return {
+          success: false,
+          error: error?.message || String(error),
+        }
       }
     },
   })
@@ -1711,6 +1889,8 @@ export function registerAIHandlers() {
 
     // Track tool executions with results
     const toolTracker = new Map<string, ToolExecution>()
+    // Keep tool input accumulation scoped to this stream to avoid cross-chat bleed.
+    const accumulatedToolInputByCallId = new Map<string, string>()
 
     try {
       // Get provider config
@@ -1944,6 +2124,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
           // Track text generated after last tool result
           let textAfterLastToolResult = ''
           let totalStreamedTextLength = 0  // Track total text sent to prevent duplicate sending
+          let streamedTextTail = '' // Track tail for spacing decisions
           let hadAnyToolCalls = false
 
           // Track tool completion for potential future todo/status integration
@@ -1980,6 +2161,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
                   event.sender.send(`ai:chunk:${channelId}`, textChunk)
                   textAfterLastToolResult += textChunk
                   totalStreamedTextLength += textChunk.length  // Track total to prevent duplicate sending
+                  streamedTextTail = (streamedTextTail + textChunk).slice(-4)
                   // Mark that AI provided text since last tool result (harness tracking)
                   textSentSinceLastResult = true
                 }
@@ -2030,6 +2212,33 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
                   currentToolInputId = startToolId
                 }
 
+                // Emit a tool call early so UI shows it before tool input progress
+                if (startToolId) {
+                  const toolName = startToolName || 'unknown_tool'
+                  if (!toolTracker.has(startToolId)) {
+                    toolTracker.set(startToolId, {
+                      id: startToolId,
+                      name: toolName,
+                      args: {},
+                      startTime: Date.now(),
+                    })
+                    event.sender.send(`ai:toolCalls:${channelId}`, [{
+                      id: startToolId,
+                      name: toolName,
+                      args: {},
+                      status: 'starting',
+                    }])
+                  } else {
+                    event.sender.send(`ai:toolCallUpdate:${channelId}`, {
+                      id: startToolId,
+                      name: toolName,
+                      args: toolTracker.get(startToolId)?.args || {},
+                      status: 'starting',
+                    })
+                  }
+                  hadAnyToolCalls = true
+                }
+
                 if (DEBUG_API_REQUESTS) {
                   console.log('[AI] tool-input-start:', { toolName: startToolName, toolId: startToolId })
                 }
@@ -2047,6 +2256,24 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
                 } else if (endInput && typeof endInput === 'object' && Object.keys(endInput).length > 0) {
                   // If it's already an object, stringify it for consistency
                   accumulatedToolInput = JSON.stringify(endInput)
+                }
+
+                if (currentToolInputId && accumulatedToolInput.trim()) {
+                  accumulatedToolInputByCallId.set(currentToolInputId, accumulatedToolInput)
+
+                  const exec = toolTracker.get(currentToolInputId)
+                  if (exec && (!exec.args || Object.keys(exec.args).length === 0)) {
+                    const typeMatch = accumulatedToolInput.match(/"type"\s*:\s*"([^"]+)"/)
+                    if (typeMatch?.[1]) {
+                      exec.args = { ...exec.args, type: typeMatch[1] }
+                      event.sender.send(`ai:toolCallUpdate:${channelId}`, {
+                        id: currentToolInputId,
+                        name: exec.name,
+                        args: exec.args,
+                        status: 'starting',
+                      })
+                    }
+                  }
                 }
                 break
               }
@@ -2068,6 +2295,9 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
 
                 accumulatedToolInput += safeInputDelta
                 toolInputCharCount += safeInputDelta.length
+                if (currentToolInputId) {
+                  accumulatedToolInputByCallId.set(currentToolInputId, accumulatedToolInput)
+                }
 
                 // Send progress update every 500ms or 1000 chars to avoid flooding
                 const now = Date.now()
@@ -2081,6 +2311,22 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
                     toolName,
                     charCount: toolInputCharCount,
                   })
+
+                  if (toolName === 'create_artifact' && currentToolInputId) {
+                    const exec = toolTracker.get(currentToolInputId)
+                    if (exec && !exec.args?.type) {
+                      const typeMatch = accumulatedToolInput.match(/"type"\s*:\s*"([^"]+)"/)
+                      if (typeMatch?.[1]) {
+                        exec.args = { ...exec.args, type: typeMatch[1] }
+                        event.sender.send(`ai:toolCallUpdate:${channelId}`, {
+                          id: currentToolInputId,
+                          name: exec.name,
+                          args: exec.args,
+                          status: 'starting',
+                        })
+                      }
+                    }
+                  }
 
                   // Disabled: Don't stream artifact preview - wait for completion
                   // This was causing Monaco editor issues and confusing UX
@@ -2103,18 +2349,27 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
                 currentToolInputName = toolName
                 toolInputCharCount = 0
 
-                toolTracker.set(toolCallId, {
-                  id: toolCallId,
-                  name: toolName,
-                  args: {},
-                  startTime: Date.now(),
-                })
-                event.sender.send(`ai:toolCalls:${channelId}`, [{
-                  id: toolCallId,
-                  name: toolName,
-                  args: {},
-                  status: 'starting',
-                }])
+                if (!toolTracker.has(toolCallId)) {
+                  toolTracker.set(toolCallId, {
+                    id: toolCallId,
+                    name: toolName,
+                    args: {},
+                    startTime: Date.now(),
+                  })
+                  event.sender.send(`ai:toolCalls:${channelId}`, [{
+                    id: toolCallId,
+                    name: toolName,
+                    args: {},
+                    status: 'starting',
+                  }])
+                } else {
+                  event.sender.send(`ai:toolCallUpdate:${channelId}`, {
+                    id: toolCallId,
+                    name: toolName,
+                    args: toolTracker.get(toolCallId)?.args || {},
+                    status: 'starting',
+                  })
+                }
                 hadAnyToolCalls = true
                 break
               }
@@ -2291,6 +2546,8 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
           if (finalText && totalStreamedTextLength === 0) {
             event.sender.send(`ai:chunk:${channelId}`, finalText)
             textAfterLastToolResult = finalText
+            totalStreamedTextLength += finalText.length
+            streamedTextTail = (streamedTextTail + finalText).slice(-4)
           }
 
           // Get usage stats
@@ -2408,10 +2665,25 @@ Be concise but informative. The user needs to understand what happened.`,
 
               clearTimeout(summaryTimeout)
 
+              // Ensure a blank line before the summary if text already streamed
+              const needsBlankLine = totalStreamedTextLength > 0
+              if (needsBlankLine) {
+                const hasDoubleNewline = streamedTextTail.endsWith('\n\n')
+                const hasSingleNewline = !hasDoubleNewline && streamedTextTail.endsWith('\n')
+                const prefix = hasDoubleNewline ? '' : (hasSingleNewline ? '\n' : '\n\n')
+                if (prefix) {
+                  event.sender.send(`ai:chunk:${channelId}`, prefix)
+                  totalStreamedTextLength += prefix.length
+                  streamedTextTail = (streamedTextTail + prefix).slice(-4)
+                }
+              }
+
               // Stream the summary
               for await (const chunk of summaryResult.textStream) {
                 if (abortController.signal.aborted) break
                 event.sender.send(`ai:chunk:${channelId}`, chunk)
+                totalStreamedTextLength += chunk.length
+                streamedTextTail = (streamedTextTail + chunk).slice(-4)
               }
 
               // Add summary usage to totals
@@ -2424,12 +2696,32 @@ Be concise but informative. The user needs to understand what happened.`,
             } catch (summaryError: any) {
               console.warn('[AI] Failed to generate summary:', summaryError.message)
               // Send a fallback message with tool results and artifacts
-              let fallbackSummary = `\n\n---\n**Task Complete**\n${buildToolContext(toolTracker)}`
+              let fallbackSummary = `---\n**Task Complete**\n${buildToolContext(toolTracker)}`
               if (subAgentArtifacts.length > 0) {
                 fallbackSummary += `\n\n**Artifacts Created:**\n${subAgentArtifacts.map(a => `- ${a.title} (${a.type})`).join('\n')}\n\nCheck the Canvas panel to view.`
               }
+              if (totalStreamedTextLength > 0) {
+                const hasDoubleNewline = streamedTextTail.endsWith('\n\n')
+                const hasSingleNewline = !hasDoubleNewline && streamedTextTail.endsWith('\n')
+                const prefix = hasDoubleNewline ? '' : (hasSingleNewline ? '\n' : '\n\n')
+                if (prefix) {
+                  fallbackSummary = prefix + fallbackSummary
+                }
+              }
               event.sender.send(`ai:chunk:${channelId}`, fallbackSummary)
             }
+          }
+
+          // Some providers occasionally end after tools without returning assistant text.
+          // Emit a small fallback so the renderer doesn't persist an opaque placeholder.
+          if (!abortController.signal.aborted && totalStreamedTextLength === 0) {
+            const usedToolsOrAgents = toolTracker.size > 0 || activeAgents.length > 0
+            const fallbackText = usedToolsOrAgents
+              ? 'Completed requested tool actions.'
+              : 'No response text was returned. Please retry.'
+            event.sender.send(`ai:chunk:${channelId}`, fallbackText)
+            totalStreamedTextLength += fallbackText.length
+            streamedTextTail = (streamedTextTail + fallbackText).slice(-4)
           }
 
           const totalTokens = promptTokens + completionTokens

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,9 +18,21 @@ import { registerCompactionHandlers } from './ipc/compaction'
 import { registerUpdateHandlers } from './ipc/updates'
 import { registerWindowHandlers } from './ipc/window'
 
+const APP_DISPLAY_NAME = 'Jelico'
+
 // Get version and git info
 const packageJson = require('../package.json')
 const APP_VERSION = packageJson.version
+
+// Ensure OS-level app naming is consistent in dev and production.
+// NOTE: Changing app name in dev can invalidate safeStorage key context and make
+// previously saved API keys unreadable. Keep the default Electron name in dev.
+if (app.isPackaged) {
+  app.setName(APP_DISPLAY_NAME)
+  if (process.platform === 'win32') {
+    app.setAppUserModelId('com.jelico.app')
+  }
+}
 
 function getGitHash(): string {
   try {
@@ -180,6 +192,7 @@ function createWindow() {
     height: 900,
     minWidth: 800,
     minHeight: 600,
+    title: APP_DISPLAY_NAME,
     frame: true,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     backgroundColor: '#08080a',

--- a/electron/prompts/capabilities/artifacts.md
+++ b/electron/prompts/capabilities/artifacts.md
@@ -89,3 +89,35 @@ Choose the right diagram for the concept:
 3. **Responsive design**: Consider different Canvas sizes
 4. **Error handling**: Include basic error states in interactive artifacts
 5. **Complete code**: Write the full implementation, not placeholders
+
+## Verification Protocol (Interactive HTML)
+
+Default behavior: you MUST self-test HTML artifacts before claiming they work.
+Only skip testing if the user explicitly asks to skip verification.
+
+1. Build a checklist from user requirements.
+2. Open a test session with `artifact_test` using `artifact_id` for the latest revision.
+3. Run at least one explicit test per requirement.
+4. Treat any failed step as a failure for the artifact until fixed.
+5. If a step fails, use `update_artifact` and re-test the failed requirements.
+6. Only claim "works" after all required checks pass.
+
+### Required evidence
+
+- Do not rely on a single screenshot.
+- For interactions, require observable change after actions (text/canvas/state).
+- Record pass/fail outcomes in your response with brief evidence.
+- If something cannot be validated with tools, mark it as `unverified` and ask for a focused manual check.
+
+### Minimum smoke test (when requirements are vague)
+
+If the user did not provide a detailed checklist, run at least:
+1. `artifact_test open` on the latest artifact revision.
+2. One interaction test on the primary control path (button/canvas/keyboard equivalent).
+3. One state-change verification (`wait_for`, `extract`, or `evaluate`) proving behavior changed.
+4. Close session and summarize what passed/failed.
+
+### Artifact naming and revisions
+
+- If you are revising the same deliverable, keep the same title and update it.
+- Do not create a new titled variant unless the user explicitly asks for a distinct artifact.

--- a/electron/prompts/core/persona.md
+++ b/electron/prompts/core/persona.md
@@ -190,6 +190,11 @@ After ALL tool calls are processed:
 5. Explain what happened, what worked, what failed
 6. State what the user should do next (if anything)
 
+For interactive HTML artifacts:
+- Do not claim "verified" unless each user requirement was tested.
+- If tests fail, update artifact and re-test before concluding.
+- Report pass/fail per requirement, not a single blanket success.
+
 NEVER end your response with just tool calls - ALWAYS provide a natural language summary afterward.
 
 ## Error Recovery & Resilience

--- a/electron/services/artifactTester.ts
+++ b/electron/services/artifactTester.ts
@@ -1,0 +1,499 @@
+import { BrowserWindow, app } from 'electron'
+import path from 'path'
+import fs from 'fs/promises'
+import { artifactDb } from './database.js'
+
+const DEFAULT_VIEWPORT = { width: 1280, height: 800 }
+const MAX_SESSIONS = 8
+
+interface ArtifactTestSession {
+  id: string
+  win: BrowserWindow
+  createdAt: number
+  lastUsedAt: number
+  artifactId?: string
+  artifactTitle?: string
+}
+
+const sessions = new Map<string, ArtifactTestSession>()
+
+function createSessionId(): string {
+  return `artifact-test-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function asErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+async function loadUrlAndWaitForLoad(win: BrowserWindow, url: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timed out while loading artifact preview'))
+    }, 10000)
+
+    const onLoad = () => {
+      cleanup()
+      resolve()
+    }
+
+    const onFail = (_: unknown, code: number, description: string) => {
+      cleanup()
+      reject(new Error(`Failed to load artifact preview (${code}): ${description}`))
+    }
+
+    const onLoadError = (error: unknown) => {
+      cleanup()
+      reject(new Error(`Failed to load artifact preview: ${asErrorMessage(error)}`))
+    }
+
+    const cleanup = () => {
+      clearTimeout(timeout)
+      win.webContents.removeListener('did-finish-load', onLoad)
+      win.webContents.removeListener('did-fail-load', onFail)
+    }
+
+    // Register listeners BEFORE starting navigation to avoid missing did-finish-load.
+    win.webContents.once('did-finish-load', onLoad)
+    win.webContents.once('did-fail-load', onFail)
+    void win.loadURL(url).catch(onLoadError)
+  })
+}
+
+async function executeInSession<T = unknown>(session: ArtifactTestSession, script: string): Promise<T> {
+  session.lastUsedAt = Date.now()
+  return session.win.webContents.executeJavaScript(script, true) as Promise<T>
+}
+
+function getSession(sessionId: string): ArtifactTestSession | null {
+  const session = sessions.get(sessionId)
+  if (!session) return null
+  if (session.win.isDestroyed()) {
+    sessions.delete(sessionId)
+    return null
+  }
+  return session
+}
+
+async function closeOldestSessionIfNeeded() {
+  if (sessions.size < MAX_SESSIONS) return
+
+  let oldest: ArtifactTestSession | null = null
+  for (const session of sessions.values()) {
+    if (!oldest || session.lastUsedAt < oldest.lastUsedAt) {
+      oldest = session
+    }
+  }
+  if (!oldest) return
+
+  try {
+    oldest.win.destroy()
+  } catch {
+    // Ignore
+  }
+  sessions.delete(oldest.id)
+}
+
+async function resolveHtmlFromArtifact(artifactId: string): Promise<{
+  html: string
+  artifactId: string
+  artifactTitle: string
+  revision: number
+}> {
+  const artifact = artifactDb.get(artifactId)
+  if (!artifact) {
+    throw new Error(`Artifact not found: ${artifactId}`)
+  }
+
+  const baseId = artifact.base_artifact_id || artifact.id
+  const latest = artifactDb.getLatestRevision(baseId) || artifact
+
+  if (latest.type !== 'html') {
+    throw new Error(`Artifact "${latest.title}" is type "${latest.type}", expected "html"`)
+  }
+
+  return {
+    html: latest.content || '',
+    artifactId: latest.id,
+    artifactTitle: latest.title,
+    revision: latest.revision || 1,
+  }
+}
+
+export async function openArtifactTestSession(input: {
+  artifactId?: string
+  html?: string
+  width?: number
+  height?: number
+}) {
+  await closeOldestSessionIfNeeded()
+
+  const width = Math.max(320, Math.min(2560, input.width || DEFAULT_VIEWPORT.width))
+  const height = Math.max(240, Math.min(1600, input.height || DEFAULT_VIEWPORT.height))
+
+  let html = input.html || ''
+  let artifactMeta: { artifactId?: string; artifactTitle?: string; revision?: number } = {}
+
+  if (input.artifactId) {
+    const resolved = await resolveHtmlFromArtifact(input.artifactId)
+    html = resolved.html
+    artifactMeta = {
+      artifactId: resolved.artifactId,
+      artifactTitle: resolved.artifactTitle,
+      revision: resolved.revision,
+    }
+  }
+
+  if (!html || !html.trim()) {
+    throw new Error('No HTML content available to open')
+  }
+
+  const win = new BrowserWindow({
+    show: false,
+    width,
+    height,
+    webPreferences: {
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+      backgroundThrottling: false,
+    },
+  })
+
+  win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+
+  const sessionId = createSessionId()
+  const session: ArtifactTestSession = {
+    id: sessionId,
+    win,
+    createdAt: Date.now(),
+    lastUsedAt: Date.now(),
+    artifactId: artifactMeta.artifactId,
+    artifactTitle: artifactMeta.artifactTitle,
+  }
+
+  sessions.set(sessionId, session)
+  win.on('closed', () => {
+    sessions.delete(sessionId)
+  })
+
+  const dataUrl = `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+  await loadUrlAndWaitForLoad(win, dataUrl)
+
+  return {
+    sessionId,
+    viewport: { width, height },
+    artifactId: artifactMeta.artifactId,
+    artifactTitle: artifactMeta.artifactTitle,
+    revision: artifactMeta.revision,
+  }
+}
+
+export async function closeArtifactTestSession(sessionId: string) {
+  const session = getSession(sessionId)
+  if (!session) {
+    return { success: false, error: `Session not found: ${sessionId}` }
+  }
+  try {
+    session.win.destroy()
+  } catch {
+    // Ignore
+  }
+  sessions.delete(sessionId)
+  return { success: true }
+}
+
+export function listArtifactTestSessions() {
+  const result: Array<{
+    sessionId: string
+    artifactId?: string
+    artifactTitle?: string
+    createdAt: number
+    lastUsedAt: number
+  }> = []
+
+  for (const [id, session] of sessions.entries()) {
+    if (session.win.isDestroyed()) {
+      sessions.delete(id)
+      continue
+    }
+    result.push({
+      sessionId: id,
+      artifactId: session.artifactId,
+      artifactTitle: session.artifactTitle,
+      createdAt: session.createdAt,
+      lastUsedAt: session.lastUsedAt,
+    })
+  }
+
+  return result.sort((a, b) => b.lastUsedAt - a.lastUsedAt)
+}
+
+export async function artifactTestClick(
+  sessionId: string,
+  selector: string,
+  expectChange = true,
+  waitAfterMs = 300
+) {
+  const session = getSession(sessionId)
+  if (!session) return { success: false, error: `Session not found: ${sessionId}` }
+
+  const payload = JSON.stringify(selector)
+  const expectChangeJson = JSON.stringify(expectChange)
+  const waitAfterMsJson = JSON.stringify(Math.max(0, Math.min(5000, waitAfterMs)))
+  const result = await executeInSession(session, `
+(() => {
+  const selector = ${payload}
+  const expectChange = ${expectChangeJson}
+  const waitAfterMs = ${waitAfterMsJson}
+  const el = document.querySelector(selector)
+  if (!el) return { success: false, error: \`Selector not found: \${selector}\` }
+
+  const hashText = (text) => {
+    let hash = 2166136261
+    for (let i = 0; i < text.length; i += 1) {
+      hash ^= text.charCodeAt(i)
+      hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+    }
+    return (hash >>> 0).toString(16)
+  }
+
+  const canvasSignature = () => {
+    const canvas = document.querySelector('canvas')
+    if (!(canvas instanceof HTMLCanvasElement)) return null
+    try {
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return null
+      const width = Math.max(1, Math.min(canvas.width || 1, 64))
+      const height = Math.max(1, Math.min(canvas.height || 1, 64))
+      const data = ctx.getImageData(0, 0, width, height).data
+      let checksum = 0
+      for (let i = 0; i < data.length; i += 16) {
+        checksum = (checksum + data[i] + data[i + 1] + data[i + 2] + data[i + 3]) % 1000000007
+      }
+      return width + 'x' + height + ':' + checksum
+    } catch {
+      return null
+    }
+  }
+
+  const snapshot = () => {
+    const text = (document.body?.innerText || '').replace(/\\s+/g, ' ').trim().slice(0, 4000)
+    return {
+      readyState: document.readyState,
+      textHash: hashText(text),
+      textLength: text.length,
+      canvasSignature: canvasSignature(),
+    }
+  }
+
+  const before = snapshot()
+
+  const rect = el.getBoundingClientRect()
+  const x = rect.left + rect.width / 2
+  const y = rect.top + rect.height / 2
+  const eventOpts = { bubbles: true, cancelable: true, view: window, clientX: x, clientY: y }
+  el.dispatchEvent(new MouseEvent('mouseover', eventOpts))
+  el.dispatchEvent(new MouseEvent('mousedown', eventOpts))
+  el.dispatchEvent(new MouseEvent('mouseup', eventOpts))
+  el.dispatchEvent(new MouseEvent('click', eventOpts))
+  if (typeof el.click === 'function') {
+    el.click()
+  }
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const after = snapshot()
+      const textChanged = before.textHash !== after.textHash
+      const canvasChanged = before.canvasSignature !== after.canvasSignature
+      const changed = textChanged || canvasChanged
+
+      if (expectChange && !changed) {
+        resolve({
+          success: false,
+          error: 'Click produced no observable UI change (text/canvas unchanged)',
+          tagName: el.tagName,
+          text: (el.textContent || '').trim().slice(0, 160),
+          observed: {
+            textChanged,
+            canvasChanged,
+            before,
+            after,
+          },
+        })
+        return
+      }
+
+      resolve({
+        success: true,
+        tagName: el.tagName,
+        text: (el.textContent || '').trim().slice(0, 160),
+        observed: {
+          textChanged,
+          canvasChanged,
+          changed,
+          before,
+          after,
+        },
+      })
+    }, waitAfterMs)
+  })
+})()
+`)
+
+  return result
+}
+
+export async function artifactTestType(
+  sessionId: string,
+  selector: string,
+  text: string,
+  append = false
+) {
+  const session = getSession(sessionId)
+  if (!session) return { success: false, error: `Session not found: ${sessionId}` }
+
+  const selectorJson = JSON.stringify(selector)
+  const textJson = JSON.stringify(text)
+  const appendJson = JSON.stringify(append)
+
+  const result = await executeInSession(session, `
+(() => {
+  const selector = ${selectorJson}
+  const text = ${textJson}
+  const append = ${appendJson}
+  const el = document.querySelector(selector)
+  if (!el) return { success: false, error: \`Selector not found: \${selector}\` }
+
+  const isInput = el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement
+  const isEditable = el instanceof HTMLElement && el.isContentEditable
+
+  if (!isInput && !isEditable) {
+    return { success: false, error: 'Target is not an input, textarea, or contenteditable element' }
+  }
+
+  if (isInput) {
+    const target = el
+    target.focus()
+    target.value = append ? (target.value + text) : text
+    target.dispatchEvent(new Event('input', { bubbles: true }))
+    target.dispatchEvent(new Event('change', { bubbles: true }))
+    return { success: true, valueLength: target.value.length }
+  }
+
+  el.focus()
+  el.textContent = append ? ((el.textContent || '') + text) : text
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+  return { success: true, valueLength: (el.textContent || '').length }
+})()
+`)
+
+  return result
+}
+
+export async function artifactTestEvaluate(sessionId: string, expression: string) {
+  const session = getSession(sessionId)
+  if (!session) return { success: false, error: `Session not found: ${sessionId}` }
+
+  try {
+    const value = await executeInSession(session, expression)
+    return { success: true, value }
+  } catch (error) {
+    return { success: false, error: asErrorMessage(error) }
+  }
+}
+
+export async function artifactTestExtract(sessionId: string, selector?: string) {
+  const session = getSession(sessionId)
+  if (!session) return { success: false, error: `Session not found: ${sessionId}` }
+
+  const selectorJson = JSON.stringify(selector || '')
+  const result = await executeInSession(session, `
+(() => {
+  const selector = ${selectorJson}
+  const target = selector ? document.querySelector(selector) : document.body
+  if (!target) return { success: false, error: \`Selector not found: \${selector}\` }
+
+  return {
+    success: true,
+    text: (target.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 4000),
+    html: (target instanceof Element ? target.outerHTML : document.documentElement.outerHTML).slice(0, 8000),
+  }
+})()
+`)
+
+  return result
+}
+
+export async function artifactTestWaitFor(input: {
+  sessionId: string
+  text?: string
+  selector?: string
+  timeoutMs?: number
+}) {
+  const session = getSession(input.sessionId)
+  if (!session) return { success: false, error: `Session not found: ${input.sessionId}` }
+
+  if (!input.text && !input.selector) {
+    return { success: false, error: 'Provide text, selector, or both for wait_for' }
+  }
+
+  const timeoutMs = Math.max(250, Math.min(60000, input.timeoutMs || 10000))
+  const start = Date.now()
+
+  let lastState: unknown = null
+  while (Date.now() - start < timeoutMs) {
+    const textJson = JSON.stringify(input.text || '')
+    const selectorJson = JSON.stringify(input.selector || '')
+    const state = await executeInSession(session, `
+(() => {
+  const expectedText = ${textJson}
+  const selector = ${selectorJson}
+  const bodyText = (document.body?.textContent || '')
+  const textMatched = expectedText ? bodyText.includes(expectedText) : true
+  const selectorMatched = selector ? !!document.querySelector(selector) : true
+  return {
+    matched: textMatched && selectorMatched,
+    textMatched,
+    selectorMatched,
+    readyState: document.readyState,
+  }
+})()
+`)
+    lastState = state
+    if ((state as any)?.matched) {
+      return {
+        success: true,
+        elapsedMs: Date.now() - start,
+        state,
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+
+  return {
+    success: false,
+    error: `Timeout waiting for expected state after ${timeoutMs}ms`,
+    elapsedMs: Date.now() - start,
+    lastState,
+  }
+}
+
+export async function artifactTestScreenshot(sessionId: string) {
+  const session = getSession(sessionId)
+  if (!session) return { success: false, error: `Session not found: ${sessionId}` }
+
+  const image = await session.win.webContents.capturePage()
+  const png = image.toPNG()
+  const outputPath = path.join(app.getPath('temp'), `jelico-artifact-test-${sessionId}-${Date.now()}.png`)
+  await fs.writeFile(outputPath, png)
+
+  const size = image.getSize()
+  return {
+    success: true,
+    path: outputPath,
+    width: size.width,
+    height: size.height,
+  }
+}

--- a/electron/services/artifactValidator.ts
+++ b/electron/services/artifactValidator.ts
@@ -16,6 +16,7 @@ export interface ValidationResult {
 function validateHtml(content: string): ValidationResult {
   const errors: string[] = []
   const warnings: string[] = []
+  let hasMalformedUndefinedAttribute = false
 
   try {
     // Check for basic HTML structure
@@ -29,6 +30,12 @@ function validateHtml(content: string): ValidationResult {
     while ((match = tagRegex.exec(content)) !== null) {
       const fullMatch = match[0]
       const tagName = match[1].toLowerCase()
+
+      // Guard against malformed tool-call repairs that inject "undefined" into quoted attributes
+      // Example bad pattern: id=undefinedgameCanvasundefined (expected id="gameCanvas")
+      if (!hasMalformedUndefinedAttribute && /\s[a-zA-Z_:][\w:.-]*\s*=\s*undefined[^>\s]*undefined/i.test(fullMatch)) {
+        hasMalformedUndefinedAttribute = true
+      }
 
       // Skip self-closing tags and void elements
       const voidElements = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr']
@@ -72,6 +79,10 @@ function validateHtml(content: string): ValidationResult {
     // Check for common issues
     if (content.includes('undefined') && content.includes('<script')) {
       warnings.push('Content contains "undefined" - possible uninitialized variable')
+    }
+
+    if (hasMalformedUndefinedAttribute) {
+      errors.push('Malformed HTML attribute values detected (contains "undefined...undefined" around attribute values). Regenerate with proper quoted attributes.')
     }
 
   } catch (e: any) {

--- a/electron/services/database.ts
+++ b/electron/services/database.ts
@@ -690,7 +690,29 @@ interface ArtifactInput {
 // Files are stored at: ~/.config/jelico/artifacts/{conversation-id}/{artifact-id}.{ext}
 export const artifactDb = {
   list(): ArtifactRow[] {
-    return [...db.artifacts].sort((a, b) => b.updated_at - a.updated_at)
+    // Return only the latest revision for each base artifact across all conversations.
+    const latestByBase = new Map<string, ArtifactRow>()
+    for (const artifact of db.artifacts) {
+      const baseId = artifact.base_artifact_id || artifact.id
+      const existing = latestByBase.get(baseId)
+      if (!existing || artifact.revision > existing.revision) {
+        latestByBase.set(baseId, artifact)
+      }
+    }
+
+    const result: ArtifactRow[] = []
+    for (const artifact of latestByBase.values()) {
+      if (artifact.file_path && artifactFileExists(artifact.file_path)) {
+        const content = readArtifactFile(artifact.file_path)
+        if (content !== null) {
+          result.push({ ...artifact, content })
+          continue
+        }
+      }
+      result.push(artifact)
+    }
+
+    return result.sort((a, b) => b.updated_at - a.updated_at)
   },
 
   get(id: string): ArtifactRow | null {

--- a/electron/services/keychain.ts
+++ b/electron/services/keychain.ts
@@ -13,6 +13,39 @@ interface KeyStore {
   [providerId: string]: string // encrypted base64 string
 }
 
+function isLikelyApiKey(value: string): boolean {
+  if (!value) return false
+  const trimmed = value.trim()
+  if (trimmed.length < 12 || trimmed.length > 512) return false
+  if (/\s/.test(trimmed)) return false
+  // Restrict to printable ASCII to avoid returning decrypted garbage bytes.
+  return /^[\x20-\x7E]+$/.test(trimmed)
+}
+
+function tryDecryptWithLegacyAppNames(buffer: Buffer): string | null {
+  const originalName = app.getName()
+  const legacyNames = ['Electron', 'jelico', 'Jelico'].filter((name) => name !== originalName)
+
+  try {
+    for (const legacyName of legacyNames) {
+      try {
+        app.setName(legacyName)
+        const value = safeStorage.decryptString(buffer)
+        if (isLikelyApiKey(value)) {
+          return value
+        }
+      } catch {
+        // Try next legacy name
+      }
+    }
+  } finally {
+    // Always restore current app name for consistent app behavior.
+    app.setName(originalName)
+  }
+
+  return null
+}
+
 function loadKeys(): KeyStore {
   try {
     const keysPath = getKeysPath()
@@ -57,10 +90,51 @@ export const keychainService = {
     try {
       if (safeStorage.isEncryptionAvailable()) {
         const buffer = Buffer.from(encrypted, 'base64')
-        return safeStorage.decryptString(buffer)
+        let recoveredApiKey: string | null = null
+
+        try {
+          const currentValue = safeStorage.decryptString(buffer)
+          if (isLikelyApiKey(currentValue)) {
+            recoveredApiKey = currentValue
+          }
+        } catch {
+          // Ignore and attempt compatibility fallbacks below.
+        }
+
+        // Compatibility fallback for legacy app-name encryption contexts.
+        if (!recoveredApiKey) {
+          recoveredApiKey = tryDecryptWithLegacyAppNames(buffer)
+          if (recoveredApiKey) {
+            // Migrate to current app identity for stable future decrypts.
+            try {
+              keys[providerId] = safeStorage.encryptString(recoveredApiKey).toString('base64')
+              saveKeys(keys)
+            } catch {
+              // Keep using recovered key even if migration write fails.
+            }
+          }
+        }
+
+        // Legacy fallback: some historical runs stored plain base64 while
+        // encryption availability changed across environments.
+        if (!recoveredApiKey) {
+          const legacyPlain = buffer.toString('utf-8')
+          if (isLikelyApiKey(legacyPlain)) {
+            recoveredApiKey = legacyPlain
+            try {
+              keys[providerId] = safeStorage.encryptString(legacyPlain).toString('base64')
+              saveKeys(keys)
+            } catch {
+              // Keep using recovered key even if migration write fails.
+            }
+          }
+        }
+
+        return recoveredApiKey
       } else {
         // Fallback: decode base64
-        return Buffer.from(encrypted, 'base64').toString('utf-8')
+        const decoded = Buffer.from(encrypted, 'base64').toString('utf-8')
+        return isLikelyApiKey(decoded) ? decoded : null
       }
     } catch {
       return null

--- a/electron/services/permissionChecker.ts
+++ b/electron/services/permissionChecker.ts
@@ -178,6 +178,9 @@ export function classifyAction(toolName: string, args: Record<string, unknown>):
     case 'update_artifact':
       return { type: 'write', description: `Create/update artifact: ${args.title || args.id}`, isDestructive: false }
 
+    case 'artifact_test':
+      return { type: 'read', description: `Artifact test action: ${args.action || 'unknown'}`, isDestructive: false }
+
     case 'execute_command': {
       const cmd = String(args.command || '')
       const classification = classifyCommand(cmd)
@@ -239,7 +242,7 @@ export async function checkPermission(
   }
 
   // Artifacts (create/update) are generally safe
-  if (toolName === 'create_artifact' || toolName === 'update_artifact') {
+  if (toolName === 'create_artifact' || toolName === 'update_artifact' || toolName === 'artifact_test') {
     return { allowed: true, reason: 'artifact_safe' }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,7 @@ export default function App() {
   // Resizable canvas panel state
   const [canvasWidth, setCanvasWidth] = useState(DEFAULT_CANVAS_WIDTH)
   const [isResizing, setIsResizing] = useState(false)
-  const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const resizeRef = useRef<{ startX: number; startWidth: number; currentWidth: number } | null>(null)
   const windowDragRef = useRef<WindowDragSession | null>(null)
   const isInteractiveTarget = useCallback((target: HTMLElement | null) => {
     if (!target) return false
@@ -204,50 +204,57 @@ export default function App() {
     })
   }, [isResizing, isInteractiveTarget])
 
+  const finishResize = useCallback(() => {
+    const current = resizeRef.current
+    if (!current) return
+    resizeRef.current = null
+    setIsResizing(false)
+    localStorage.setItem('jelico-canvas-width', String(current.currentWidth))
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+  }, [])
+
   // Handle resize drag
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
+    e.stopPropagation()
     setIsResizing(true)
-    resizeRef.current = { startX: e.clientX, startWidth: canvasWidth }
-  }, [canvasWidth])
-
-  useEffect(() => {
-    if (!isResizing) return
-
-    let currentWidth = canvasWidth
-
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!resizeRef.current) return
-
-      // Moving left increases width, moving right decreases
-      const delta = resizeRef.current.startX - e.clientX
-      const newWidth = Math.min(MAX_CANVAS_WIDTH, Math.max(MIN_CANVAS_WIDTH, resizeRef.current.startWidth + delta))
-      currentWidth = newWidth
-      setCanvasWidth(newWidth)
+    resizeRef.current = {
+      startX: e.clientX,
+      startWidth: canvasWidth,
+      currentWidth: canvasWidth,
     }
-
-    const handleMouseUp = () => {
-      setIsResizing(false)
-      resizeRef.current = null
-      // Save to localStorage using tracked width
-      localStorage.setItem('jelico-canvas-width', String(currentWidth))
-    }
-
-    // Add listeners to document so they fire even if mouse leaves the handle
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-
-    // Prevent text selection during drag
     document.body.style.userSelect = 'none'
     document.body.style.cursor = 'col-resize'
+  }, [canvasWidth])
 
+  const handleResizeMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const current = resizeRef.current
+    if (!current) return
+
+    // Mouse released outside normal flow (e.g., over iframe), force-finish resize.
+    if ((e.buttons & 1) === 0) {
+      finishResize()
+      return
+    }
+
+    // Moving left increases width, moving right decreases.
+    const delta = current.startX - e.clientX
+    const newWidth = Math.min(MAX_CANVAS_WIDTH, Math.max(MIN_CANVAS_WIDTH, current.startWidth + delta))
+    current.currentWidth = newWidth
+    setCanvasWidth(newWidth)
+  }, [finishResize])
+
+  const handleResizeEnd = useCallback(() => {
+    finishResize()
+  }, [finishResize])
+
+  useEffect(() => {
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
       document.body.style.userSelect = ''
       document.body.style.cursor = ''
     }
-  }, [isResizing]) // Only depend on isResizing - don't re-add listeners on width change
+  }, [])
 
   // Handle onboarding completion - save profile to soul system
   const handleOnboardingComplete = useCallback(async (profile: OnboardingProfile) => {
@@ -339,7 +346,8 @@ export default function App() {
               {/* Canvas panel with dynamic width */}
               <div
                 style={{ width: canvasWidth }}
-                className={`flex-shrink-0 ${isResizing ? 'pointer-events-none' : ''}`}
+                className="flex-shrink-0"
+                data-window-toggle="ignore"
               >
                 <CanvasPanel />
               </div>
@@ -347,6 +355,16 @@ export default function App() {
           )}
         </div>
       </main>
+
+      {isResizing && (
+        <div
+          className="fixed inset-0 z-[60] cursor-col-resize"
+          data-window-toggle="ignore"
+          onMouseMove={handleResizeMove}
+          onMouseUp={handleResizeEnd}
+          onMouseLeave={handleResizeEnd}
+        />
+      )}
 
       {/* Settings modal */}
       {settingsOpen && (

--- a/src/components/Canvas/CanvasPanel.tsx
+++ b/src/components/Canvas/CanvasPanel.tsx
@@ -200,7 +200,7 @@ export function CanvasPanel() {
   const hasMultipleRevisions = revisions.length > 1
 
   return (
-    <div className="w-full h-full bg-bg-surface flex flex-col overflow-hidden">
+    <div className="w-full h-full bg-bg-surface flex flex-col overflow-hidden" data-window-toggle="ignore">
       {/* Header */}
       <div className="h-14 flex items-center justify-between px-4 border-b border-border flex-shrink-0">
         <div className="flex items-center gap-2 min-w-0 flex-1">

--- a/src/components/Chat/ChatArea.tsx
+++ b/src/components/Chat/ChatArea.tsx
@@ -20,10 +20,32 @@ import { formatElapsedTime } from '../../utils/format'
 const MIN_STATUS_DISPLAY_MS = 600
 
 export function ChatArea() {
-  const { messages, isStreaming, streamingContent, streamingToolCalls, streamingToolResults, streamingSegments, systemNotifications, activeConversationId, regenerateLastResponse, modeSwitchReason, modeTransitioning, lastCompletedTool, statusDisplayQueue, toolInputProgress, streamingStartTime } = useChatStore()
+  const {
+    messages,
+    isStreaming,
+    streamingContent,
+    streamingToolCalls,
+    streamingToolResults,
+    streamingSegments,
+    systemNotifications,
+    activeConversationId,
+    regenerateLastResponse,
+    modeSwitchReason,
+    modeTransitioning,
+    lastCompletedTool,
+    statusDisplayQueue,
+    toolInputProgress,
+    streamingStartTime,
+    interruptedConversations,
+    resumeInterruptedConversation,
+    dismissInterruptedConversation,
+    getRegenerateArtifactImpact,
+    error,
+    clearError,
+  } = useChatStore()
   const { activeProviderId, activeModel } = useProviderStore()
   const { isProcessing, processingMessage } = useUIStore()
-  const { isCompacting } = useContextStore()
+  const { isConversationCompacting } = useContextStore()
   const { setActiveRequest } = useClarificationStore()
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const [userName, setUserName] = useState<string | null>(null)
@@ -71,8 +93,85 @@ export function ChatArea() {
   // Handler for regenerating the last response
   const handleRegenerate = useCallback(async () => {
     if (!activeProviderId || !activeModel) return
+
+    const impact = getRegenerateArtifactImpact()
+    if (impact.artifacts.length > 0) {
+      const previewLines = impact.artifacts
+        .slice(0, 5)
+        .map((artifact) => `- ${artifact.title}`)
+      const remaining = impact.artifacts.length - previewLines.length
+      const body = [
+        `Regenerating this response will delete ${impact.artifacts.length} artifact(s) created by that turn.`,
+        '',
+        ...previewLines,
+        remaining > 0 ? `- ...and ${remaining} more` : null,
+        '',
+        'This also removes their files from the workspace/sandbox.',
+        'Do you want to continue?',
+      ]
+        .filter(Boolean)
+        .join('\n')
+
+      if (!window.confirm(body)) {
+        return
+      }
+    }
+
     await regenerateLastResponse(activeProviderId, activeModel)
-  }, [activeProviderId, activeModel, regenerateLastResponse])
+  }, [activeProviderId, activeModel, getRegenerateArtifactImpact, regenerateLastResponse])
+
+  const interruptedStream = activeConversationId
+    ? interruptedConversations[activeConversationId]
+    : null
+  const isCompacting = activeConversationId
+    ? isConversationCompacting(activeConversationId)
+    : false
+
+  const formatArtifactType = (args: Record<string, unknown>) => {
+    const rawType = String(args.type || '').toLowerCase()
+    const rawLang = String(args.language || '').toLowerCase()
+    const rawTitle = String(args.title || '').toLowerCase()
+    const capitalize = (value: string) => (value ? value.charAt(0).toUpperCase() + value.slice(1) : value)
+
+    if (rawType === 'html' || rawTitle.endsWith('.html') || rawTitle.endsWith('.htm')) return 'HTML page'
+    if (rawType === 'svg' || rawTitle.endsWith('.svg')) return 'SVG graphic'
+    if (rawType === 'mermaid' || rawTitle.endsWith('.mmd')) return 'diagram'
+    if (rawType === 'document') return rawTitle.endsWith('.md') ? 'markdown document' : 'document'
+    if (rawType === 'code') return rawLang ? `${capitalize(rawLang)} code` : 'code'
+    if (rawLang) return `${capitalize(rawLang)} code`
+    return rawType || 'artifact'
+  }
+
+  const formatArtifactTestStatus = (args: Record<string, unknown>, completed: boolean) => {
+    const action = String(args.action || '').toLowerCase()
+    if (completed) {
+      switch (action) {
+        case 'open': return 'Artifact test session ready'
+        case 'click': return 'Artifact interaction complete'
+        case 'type': return 'Artifact input complete'
+        case 'evaluate': return 'Artifact check complete'
+        case 'extract': return 'Artifact content captured'
+        case 'wait_for': return 'Artifact state confirmed'
+        case 'screenshot': return 'Artifact screenshot captured'
+        case 'close': return 'Artifact test session closed'
+        case 'list_sessions': return 'Artifact sessions listed'
+        default: return 'Artifact test complete'
+      }
+    }
+
+    switch (action) {
+      case 'open': return 'Opening artifact test session...'
+      case 'click': return 'Testing artifact interaction...'
+      case 'type': return 'Typing into artifact...'
+      case 'evaluate': return 'Evaluating artifact state...'
+      case 'extract': return 'Extracting artifact content...'
+      case 'wait_for': return 'Waiting for artifact state...'
+      case 'screenshot': return 'Capturing artifact screenshot...'
+      case 'close': return 'Closing artifact test session...'
+      case 'list_sessions': return 'Checking artifact test sessions...'
+      default: return 'Testing artifact...'
+    }
+  }
 
   // Show new chat UI when no conversation selected OR empty conversation
   const showNewChatUI = !activeConversationId || (messages.length === 0 && !isStreaming)
@@ -109,6 +208,40 @@ export function ChatArea() {
             onRegenerate={handleRegenerate}
             userName={userName || undefined}
           />
+
+          {interruptedStream && !isStreaming && (
+            <div className="mt-4 rounded-lg border border-border bg-bg-surface px-3 py-2 flex items-center justify-between gap-3">
+              <p className="text-xs text-text-secondary">
+                Looks like this response stopped. Restart where it left off?
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => resumeInterruptedConversation(activeConversationId || undefined)}
+                  className="px-2 py-1 text-xs font-medium rounded-md bg-accent text-bg-surface hover:opacity-90 transition-opacity"
+                >
+                  Restart
+                </button>
+                <button
+                  onClick={() => dismissInterruptedConversation(activeConversationId || undefined)}
+                  className="px-2 py-1 text-xs font-medium rounded-md border border-border text-text-muted hover:text-text-primary hover:border-border-strong transition-colors"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-4 rounded-lg border border-error/40 bg-error/10 px-3 py-2 flex items-center justify-between gap-3">
+              <p className="text-xs text-error">{error}</p>
+              <button
+                onClick={clearError}
+                className="px-2 py-1 text-xs font-medium rounded-md border border-error/40 text-error hover:bg-error/10 transition-colors"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
 
           {/* Status indicator - final row in chat view with braille animation */}
           {(isStreaming || isCompacting || isProcessing || modeTransitioning) && (
@@ -152,9 +285,11 @@ export function ChatArea() {
                              }
                            }
                            case 'create_artifact':
-                             return args.title ? `Created: ${String(args.title).slice(0, 25)}` : 'Artifact created'
+                             return `Created ${formatArtifactType(args)}`
                            case 'update_artifact':
-                             return args.title ? `Updated: ${String(args.title).slice(0, 25)}` : 'Artifact updated'
+                             return `Updated ${formatArtifactType(args)}`
+                           case 'artifact_test':
+                             return formatArtifactTestStatus(args, true)
                            case 'spawn_agent':
                              return args.name ? `Started: ${args.name}` : 'Sub-agent started'
                            case 'wait_for_agent':
@@ -210,9 +345,11 @@ export function ChatArea() {
                              }
                            }
                            case 'create_artifact':
-                             return args.title ? `Creating: ${String(args.title).slice(0, 30)}` : 'Creating artifact...'
+                             return `Creating ${formatArtifactType(args)}...`
                            case 'update_artifact':
-                             return args.title ? `Updating: ${String(args.title).slice(0, 30)}` : 'Updating artifact...'
+                             return `Updating ${formatArtifactType(args)}...`
+                           case 'artifact_test':
+                             return formatArtifactTestStatus(args, false)
                            case 'spawn_agent':
                              return args.name ? `Starting sub-agent: ${args.name}` : 'Starting sub-agent...'
                            case 'wait_for_agent':
@@ -266,9 +403,23 @@ export function ChatArea() {
                        const { toolName } = toolInputProgress
                        switch (toolName) {
                          case 'create_artifact':
-                           return 'Generating artifact...'
+                           return `Creating ${
+                             formatArtifactType(
+                               [...streamingToolCalls]
+                                 .reverse()
+                                 .find((tc) => tc.name === 'create_artifact')
+                                 ?.args || {}
+                             )
+                           }...`
                          case 'update_artifact':
-                           return 'Updating artifact...'
+                           return `Updating ${
+                             formatArtifactType(
+                               [...streamingToolCalls]
+                                 .reverse()
+                                 .find((tc) => tc.name === 'update_artifact')
+                                 ?.args || {}
+                             )
+                           }...`
                          case 'write_file':
                            return 'Writing file...'
                          case 'execute_command':
@@ -288,8 +439,10 @@ export function ChatArea() {
                          switch (name) {
                            case 'spawn_agent': return 'Starting sub-agent...'
                            case 'wait_for_agent': return 'Waiting for sub-agent...'
-                           case 'create_artifact': return 'Creating artifact...'
-                           case 'update_artifact': return 'Updating artifact...'
+                           case 'create_artifact':
+                             return `Creating ${formatArtifactType(pendingTool.args || {})}...`
+                           case 'update_artifact':
+                             return `Updating ${formatArtifactType(pendingTool.args || {})}...`
                            case 'read_file': return 'Reading file...'
                            case 'write_file': return 'Writing file...'
                            case 'execute_command': return 'Running command...'
@@ -297,6 +450,8 @@ export function ChatArea() {
                            case 'list_directory': return 'Exploring directory...'
                            case 'web_search': return 'Searching the web...'
                            case 'web_fetch': return 'Fetching page...'
+                           case 'artifact_test':
+                             return formatArtifactTestStatus(pendingTool.args || {}, false)
                            case 'ask_user_question': return 'Preparing question...'
                            default: return `Running ${name.replace(/_/g, ' ')}...`
                          }

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -35,6 +35,12 @@ const ACCEPTED_EXTENSIONS = '.png,.jpg,.jpeg,.gif,.webp,.txt,.md,.json,.pdf,.doc
 
 // Line threshold for collapsing pasted content
 const PASTE_COLLAPSE_THRESHOLD = 10
+const NEW_CHAT_DRAFT_KEY = '__new__'
+const chatDraftsByConversation = new Map<string, string>()
+
+function getDraftKey(conversationId: string | null): string {
+  return conversationId || NEW_CHAT_DRAFT_KEY
+}
 
 interface ChatInputProps {
   disabled?: boolean
@@ -61,6 +67,30 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
   // const recordingTimerRef = useRef<NodeJS.Timeout | null>(null)
   const { sendMessage, stopStreaming, messageQueue, activeConversationId } = useChatStore()
   const { activeProviderId, activeModel } = useProviderStore()
+
+  const resizeTextarea = useCallback((content: string) => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    textarea.style.height = 'auto'
+    // Chat view (not centered): compact 1-line style, grows as needed
+    // Welcome screen (centered): taller 4-line style
+    const minHeight = centered ? 96 : 24
+    const maxHeight = centered ? 200 : 150
+    if (!content) {
+      textarea.style.height = `${minHeight}px`
+      return
+    }
+    const newHeight = Math.max(textarea.scrollHeight, minHeight)
+    textarea.style.height = `${Math.min(newHeight, maxHeight)}px`
+  }, [centered])
+
+  // Restore draft when switching conversations (including new-chat view)
+  useEffect(() => {
+    const draft = chatDraftsByConversation.get(getDraftKey(activeConversationId)) || ''
+    setInput(draft)
+    resizeTextarea(draft)
+  }, [activeConversationId, resizeTextarea])
 
   // Robust focus management - handles view transitions and dialog dismissals
   useEffect(() => {
@@ -242,6 +272,7 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
 
   const handleSubmit = useCallback(async () => {
     if ((!input.trim() && attachments.length === 0) || !activeProviderId || !activeModel) return
+    const trimmedInput = input.trim()
 
     // Convert attachments to MessageAttachment format
     const messageAttachments: MessageAttachment[] = await Promise.all(
@@ -275,20 +306,21 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
       })
     )
 
-    sendMessage(
-      input.trim(),
-      activeProviderId,
-      activeModel,
-      messageAttachments.length > 0 ? messageAttachments : undefined
-    )
-    setInput('')
-    setAttachments([])
-
-    // Reset textarea height to appropriate min for context
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto'
+    try {
+      await sendMessage(
+        trimmedInput,
+        activeProviderId,
+        activeModel,
+        messageAttachments.length > 0 ? messageAttachments : undefined
+      )
+      setInput('')
+      chatDraftsByConversation.delete(getDraftKey(activeConversationId))
+      setAttachments([])
+      resizeTextarea('')
+    } catch (error) {
+      console.error('[ChatInput] Failed to send message:', error)
     }
-  }, [input, attachments, activeProviderId, activeModel, sendMessage, centered])
+  }, [input, attachments, activeProviderId, activeModel, sendMessage, activeConversationId, resizeTextarea])
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -298,19 +330,15 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
   }
 
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setInput(e.target.value)
-
-    // Auto-resize textarea (only grow beyond min height)
-    const textarea = textareaRef.current
-    if (textarea) {
-      textarea.style.height = 'auto'
-      // Chat view (not centered): compact 1-line style, grows as needed
-      // Welcome screen (centered): taller 4-line style
-      const minHeight = centered ? 96 : 24 // 4 lines vs 1 line
-      const maxHeight = centered ? 200 : 150 // Allow less growth in chat view
-      const newHeight = Math.max(textarea.scrollHeight, minHeight)
-      textarea.style.height = `${Math.min(newHeight, maxHeight)}px`
+    const nextValue = e.target.value
+    setInput(nextValue)
+    const draftKey = getDraftKey(activeConversationId)
+    if (nextValue) {
+      chatDraftsByConversation.set(draftKey, nextValue)
+    } else {
+      chatDraftsByConversation.delete(draftKey)
     }
+    resizeTextarea(nextValue)
   }
 
   const handleStop = () => {

--- a/src/components/Chat/Message.tsx
+++ b/src/components/Chat/Message.tsx
@@ -89,6 +89,9 @@ export function Message({
   const toolResults = isStreaming ? streamingToolResults : message.toolResults
   // Segments are only available during streaming
   const segments = isStreaming ? streamingSegments : undefined
+  const normalizedContent = message.content === '(Used tools)' && ((toolCalls?.length || 0) > 0 || (toolResults?.length || 0) > 0)
+    ? 'Completed requested tool actions.'
+    : message.content
 
   const handleCopy = async () => {
     try {
@@ -293,8 +296,9 @@ export function Message({
             <>
               {segments.map((segment, idx) => {
                 if (segment.type === 'text') {
+                  const needsSpacing = segments[idx - 1]?.type === 'tool'
                   return (
-                    <div key={`text-${idx}`}>
+                    <div key={`text-${idx}`} className={needsSpacing ? 'mt-3' : undefined}>
                       {renderMarkdown(segment.content || (isStreaming ? '▊' : ''))}
                     </div>
                   )
@@ -319,7 +323,9 @@ export function Message({
             </>
           ) : (
             <>
-              {/* Fallback: Show tool calls first (for saved messages without segments) */}
+              {/* Fallback: Show text first (for saved messages without segments) */}
+              {renderMarkdown(normalizedContent || (isStreaming ? '▊' : ''))}
+              {/* Then show tool calls */}
               {toolCalls && toolCalls.length > 0 && (
                 <ToolCallDisplay
                   toolCalls={toolCalls}
@@ -327,15 +333,13 @@ export function Message({
                   isStreaming={isStreaming}
                 />
               )}
-              {/* Then show text content */}
-              {renderMarkdown(message.content || (isStreaming ? '▊' : ''))}
             </>
           )}
 
           {/* Message actions for assistant messages (not while streaming) */}
           {isAssistant && !isStreaming && (
-            <MessageActions
-              content={message.content}
+              <MessageActions
+              content={normalizedContent}
               toolCalls={toolCalls}
               toolResults={toolResults}
               usage={isLastAssistantMessage ? message.usage : undefined}

--- a/src/components/Chat/ToolCallDisplay.tsx
+++ b/src/components/Chat/ToolCallDisplay.tsx
@@ -31,6 +31,7 @@ const TOOL_LABELS: Record<string, string> = {
   // Artifacts
   create_artifact: 'Create Artifact',
   update_artifact: 'Update Artifact',
+  artifact_test: 'Test Artifact',
   // Sub-agents - spawn_agent handled specially below
   spawn_agent: 'Sub-agent',
   get_agent_status: 'Check Agent',
@@ -138,6 +139,32 @@ function formatToolResult(result: unknown): { content: string; isError: boolean 
       return { content: String(obj.message), isError: false }
     }
 
+    // Artifact test sessions list
+    if (obj.sessions && Array.isArray(obj.sessions)) {
+      if (obj.sessions.length === 0) {
+        return { content: 'No active artifact test sessions', isError: false }
+      }
+      const content = obj.sessions
+        .map((session: any) => {
+          const title = session.artifactTitle || session.artifactId || 'Untitled'
+          return `• ${session.sessionId} (${title})`
+        })
+        .join('\n')
+      return { content, isError: false }
+    }
+
+    // Artifact test open/screenshot summaries
+    if (obj.sessionId || (obj.path && obj.width && obj.height)) {
+      const lines: string[] = []
+      if (obj.sessionId) lines.push(`Session: ${obj.sessionId}`)
+      if (obj.artifactTitle) lines.push(`Artifact: ${obj.artifactTitle}`)
+      if (obj.revision) lines.push(`Revision: v${obj.revision}`)
+      if (obj.path) lines.push(`Screenshot: ${obj.path}`)
+      if (obj.width && obj.height) lines.push(`Viewport: ${obj.width}x${obj.height}`)
+      if (obj.value !== undefined) lines.push(`Value: ${JSON.stringify(obj.value)}`)
+      return { content: lines.join('\n') || JSON.stringify(obj, null, 2), isError: false }
+    }
+
     // Default: pretty JSON
     return { content: JSON.stringify(result, null, 2), isError: false }
   }
@@ -218,6 +245,25 @@ export function SingleToolCallDisplay({
       case 'update_artifact':
         if (args.title) return `${baseName}: ${String(args.title).slice(0, 30)}`
         break
+      case 'artifact_test': {
+        const action = args.action ? String(args.action).replace(/_/g, ' ') : ''
+        if (action === 'click' && args.selector) {
+          return `${baseName}: click ${String(args.selector).slice(0, 30)}`
+        }
+        if (action === 'type' && args.selector) {
+          return `${baseName}: type ${String(args.selector).slice(0, 30)}`
+        }
+        if (action === 'wait for' && (args.selector || args.text)) {
+          return `${baseName}: wait for`
+        }
+        if (action === 'open' && args.artifact_id) {
+          return `${baseName}: open ${String(args.artifact_id).slice(0, 12)}`
+        }
+        if (action) {
+          return `${baseName}: ${action}`
+        }
+        break
+      }
     }
 
     return baseName
@@ -226,9 +272,64 @@ export function SingleToolCallDisplay({
   const hasResult = toolResult !== undefined
   const formattedResult = hasResult ? formatToolResult(toolResult.result) : null
 
+  const formatArtifactType = () => {
+    const rawType = String(toolCall.args?.type || '').toLowerCase()
+    const rawLang = String(toolCall.args?.language || '').toLowerCase()
+    const rawTitle = String(toolCall.args?.title || '').toLowerCase()
+    const rawContent = typeof toolCall.args?.content === 'string'
+      ? toolCall.args.content.slice(0, 240).toLowerCase()
+      : ''
+    const capitalize = (value: string) => value ? value.charAt(0).toUpperCase() + value.slice(1) : value
+
+    switch (rawType) {
+      case 'html':
+        return 'HTML page'
+      case 'svg':
+        return 'SVG graphic'
+      case 'mermaid':
+        return 'diagram'
+      case 'document':
+        return 'document'
+      case 'code':
+        return rawLang ? `${capitalize(rawLang)} code` : 'code'
+      default:
+        if (rawTitle.endsWith('.html') || rawTitle.endsWith('.htm') || rawContent.includes('<html')) {
+          return 'HTML page'
+        }
+        if (rawTitle.endsWith('.svg') || rawContent.includes('<svg')) {
+          return 'SVG graphic'
+        }
+        if (
+          rawTitle.endsWith('.mmd') ||
+          rawContent.includes('graph ') ||
+          rawContent.includes('flowchart') ||
+          rawContent.includes('sequencediagram')
+        ) {
+          return 'diagram'
+        }
+        if (rawTitle.endsWith('.md') || rawTitle.endsWith('.markdown')) {
+          return 'markdown document'
+        }
+        if (rawTitle.endsWith('.txt')) {
+          return 'text document'
+        }
+        if (rawLang) {
+          return `${capitalize(rawLang)} code`
+        }
+        return rawType ? rawType : 'artifact'
+    }
+  }
+
   // Use explicit status if available, otherwise infer from result presence
   const status = toolCall.status || (hasResult ? 'complete' : (isStreaming ? 'executing' : 'complete'))
   const isInProgress = status === 'starting' || status === 'executing'
+
+  const isExpandable = (() => {
+    if (toolCall.name === 'create_artifact' && !hasResult && !formattedResult?.isError) {
+      return false
+    }
+    return true
+  })()
 
   // Get artifact info if this is a create_artifact call
   const artifactTitle = toolCall.name === 'create_artifact' && toolCall.args?.title
@@ -249,13 +350,19 @@ export function SingleToolCallDisplay({
     <div className="border border-border rounded-lg overflow-hidden bg-bg-deep">
       {/* Header */}
       <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-3 py-2 hover:bg-bg-hover transition-colors text-left"
+        onClick={isExpandable ? () => setExpanded(!expanded) : undefined}
+        className={`w-full flex items-center gap-2 px-3 py-2 text-left ${
+          isExpandable ? 'hover:bg-bg-hover transition-colors' : ''
+        }`}
       >
-        {expanded ? (
-          <ChevronDown className="w-4 h-4 text-text-muted flex-shrink-0" />
+        {isExpandable ? (
+          expanded ? (
+            <ChevronDown className="w-4 h-4 text-text-muted flex-shrink-0" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-text-muted flex-shrink-0" />
+          )
         ) : (
-          <ChevronRight className="w-4 h-4 text-text-muted flex-shrink-0" />
+          <span className="w-4 h-4 flex-shrink-0" />
         )}
 
         <span className="text-sm font-medium text-accent flex-1 truncate">{label}</span>
@@ -291,7 +398,7 @@ export function SingleToolCallDisplay({
         <div className="px-3 py-2 border-t border-border bg-bg-surface flex items-center gap-2">
           <Loader2 className="w-3 h-3 animate-spin text-accent" />
           <span className="text-xs text-text-muted">
-            Creating {toolCall.args?.title ? `"${String(toolCall.args.title)}"` : 'artifact'}...
+            Creating {formatArtifactType()}...
           </span>
         </div>
       )}
@@ -318,7 +425,7 @@ export function SingleToolCallDisplay({
       )}
 
       {/* Expanded content - collapsible sections */}
-      {expanded && (
+      {expanded && isExpandable && (
         <div className="border-t border-border bg-bg-surface">
           {/* Sub-agent live status when expanded - pulsing dot instead of spinner (header already has spinner) */}
           {toolCall.name === 'spawn_agent' && subAgent && (subAgent.status === 'running' || subAgent.status === 'pending') && subAgent.latestUpdate && (
@@ -387,7 +494,17 @@ export function ToolCallDisplay({ toolCalls, toolResults = [], isStreaming }: To
 
   return (
     <div className="space-y-2 my-3">
-      {/* Completed actions - collapsible section */}
+      {/* Active tool calls - shown normally */}
+      {activeTools.map((toolCall, index) => (
+        <SingleToolCallDisplay
+          key={toolCall.id || `active-${index}`}
+          toolCall={toolCall}
+          toolResult={resultsMap.get(toolCall.id)}
+          isStreaming={isStreaming}
+        />
+      ))}
+
+      {/* Completed actions - collapsible section (shown last) */}
       {completedTools.length > 0 && (
         <div className="border border-border rounded-lg overflow-hidden bg-bg-deep">
           <button
@@ -419,16 +536,6 @@ export function ToolCallDisplay({ toolCalls, toolResults = [], isStreaming }: To
           )}
         </div>
       )}
-
-      {/* Active tool calls - shown normally */}
-      {activeTools.map((toolCall, index) => (
-        <SingleToolCallDisplay
-          key={toolCall.id || `active-${index}`}
-          toolCall={toolCall}
-          toolResult={resultsMap.get(toolCall.id)}
-          isStreaming={isStreaming}
-        />
-      ))}
     </div>
   )
 }

--- a/src/components/Layout/ContextIndicator.tsx
+++ b/src/components/Layout/ContextIndicator.tsx
@@ -13,12 +13,15 @@ import { useUIStore } from '../../stores/ui'
 
 export function ContextIndicator() {
   const { activeConversationId, messages, isStreaming } = useChatStore()
-  const { getContextUsage, isCompacting } = useContextStore()
+  const { getContextUsage, isConversationCompacting } = useContextStore()
   const { activeModel } = useProviderStore()
   const { showContextText, toggleContextText } = useUIStore()
 
   // Get context usage for current conversation
   const contextUsage = activeConversationId ? getContextUsage(activeConversationId) : null
+  const isCompacting = activeConversationId
+    ? isConversationCompacting(activeConversationId)
+    : false
 
   // Only show when there's context to display
   const conversationMessages = messages.filter(m => m.conversationId === activeConversationId)

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '../../stores/ui'
 import { useArtifactStore, type ArtifactType } from '../../stores/artifacts'
 import { useSandboxStore } from '../../stores/sandbox'
 import { TransferDialog } from '../Conversations/TransferDialog'
+import { BrailleLoader } from '../StatusIndicators'
 
 const ARTIFACT_ICONS: Record<ArtifactType, React.ComponentType<{ className?: string }>> = {
   code: FileCode,
@@ -86,7 +87,7 @@ function getDaysOld(timestamp: number): number {
 }
 
 export function Sidebar() {
-  const { conversations, activeConversationId, setActiveConversation, deleteConversation } = useChatStore()
+  const { conversations, activeConversationId, setActiveConversation, deleteConversation, conversationStreams } = useChatStore()
   const { sidebarCollapsed, openSettings } = useUIStore()
   const { artifacts, selectArtifact, openCanvas } = useArtifactStore()
   const { loadFiles: loadSandboxFiles } = useSandboxStore()
@@ -234,6 +235,7 @@ export function Sidebar() {
               const isExpanded = expandedConversations.has(conv.id)
               const isActive = activeConversationId === conv.id
               const isSandboxConversation = !conv.workspaceId
+              const isProcessing = conversationStreams[conv.id]?.isStreaming === true
 
               const daysOld = getDaysOld(conv.createdAt)
 
@@ -265,7 +267,12 @@ export function Sidebar() {
                     ) : (
                       <div className="w-4 flex-shrink-0" /> /* Spacer for alignment */
                     )}
-                    <span className="flex-1 break-words">{conv.title}</span>
+                    <div className="flex-1 min-w-0 flex items-center gap-1.5">
+                      {isProcessing && (
+                        <BrailleLoader className="text-xs text-accent flex-shrink-0" />
+                      )}
+                      <span className="break-words">{conv.title}</span>
+                    </div>
                     {/* Days old badge (only for chats 2+ days old) */}
                     {daysOld >= 2 && (
                       <span className="text-[10px] text-text-faint tabular-nums mr-1">

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,28 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.11.0',
+    date: '2026-02-06',
+    changes: {
+      added: [
+        'Artifact testing tool now supports hidden browser sessions for open/click/type/evaluate/extract/wait/screenshot workflows',
+        'Regenerate now warns before deleting artifacts created by the last assistant turn',
+        'Regenerate impact preview now lists affected artifacts before confirmation',
+      ],
+      changed: [
+        'HTML artifact workflow now requires self-testing by default unless users explicitly ask to skip verification',
+        'Artifact verification guidance now enforces requirement-by-requirement pass/fail reporting',
+        'Regenerate artifact cleanup now targets artifacts created by the assistant turn instead of broad timestamp-only matching',
+      ],
+      fixed: [
+        'Artifact test open no longer times out after successful loads due to load-event race conditions',
+        'Artifact test click now fails when no observable UI change occurs, preventing false-positive validation claims',
+        'Artifact test now accepts both snake_case and camelCase session/action parameter aliases',
+        'HTML artifact validation now rejects malformed undefined-wrapped attribute values before artifact creation',
+      ],
+    },
+  },
+  {
     version: '0.10.1',
     date: '2026-02-05',
     changes: {

--- a/src/stores/artifacts.ts
+++ b/src/stores/artifacts.ts
@@ -120,6 +120,40 @@ export const useArtifactStore = create<ArtifactStore>((set, get) => ({
 
   addArtifact: async (artifact) => {
     try {
+      const normalizedTitle = artifact.title.trim().toLowerCase()
+      const existing = get()
+        .artifacts
+        .filter((a) =>
+          a.conversationId === artifact.conversationId &&
+          a.type === artifact.type &&
+          a.title.trim().toLowerCase() === normalizedTitle
+        )
+        .sort((a, b) => b.updatedAt - a.updatedAt)[0]
+
+      if (existing) {
+        const updatedRow: ArtifactRow | null = await window.jelico.artifacts.update(existing.id, {
+          conversationId: artifact.conversationId,
+          type: artifact.type,
+          title: artifact.title,
+          content: artifact.content,
+          language: artifact.language,
+          filePath: artifact.filePath,
+        })
+
+        if (updatedRow) {
+          const updatedArtifact = rowToArtifact(updatedRow)
+          set((state) => ({
+            artifacts: state.artifacts.map((a) =>
+              a.id === existing.id ? updatedArtifact : a
+            ),
+            selectedArtifactId: updatedArtifact.id,
+            selectedRevisionId: null,
+            canvasOpen: true,
+          }))
+          return updatedArtifact
+        }
+      }
+
       const row: ArtifactRow = await window.jelico.artifacts.create({
         conversationId: artifact.conversationId,
         type: artifact.type,

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { AgentMode } from '../lib/modes'
 import { useArtifactStore } from './artifacts'
+import type { Artifact } from './artifacts'
 import { useWorkspaceStore } from './workspaces'
 import { useAgentStore } from './agents'
 import { useSkillStore } from './skills'
@@ -73,6 +74,7 @@ interface QueuedMessage {
   attachments?: MessageAttachment[]
   providerId: string
   model: string
+  conversationId?: string | null
 }
 
 // System notifications that appear inline in chat
@@ -100,10 +102,36 @@ interface StatusDisplayItem {
   completedAt?: number
 }
 
+interface ConversationStreamState {
+  isStreaming: boolean
+  streamingContent: string
+  streamingToolCalls: ToolCall[]
+  streamingToolResults: ToolResult[]
+  streamingSegments: StreamingSegment[]
+  statusDisplayQueue: StatusDisplayItem[]
+  toolInputProgress: { toolName: string; charCount: number } | null
+  isReasoning: boolean
+  reasoningContent: string
+  streamingStartTime: number | null
+  lastCompletedTool: { name: string; args: Record<string, unknown>; completedAt: number } | null
+}
+
+interface PendingStreamCheckpoint {
+  providerId: string
+  model: string
+  startedAt: number
+}
+
+interface InterruptedConversationState extends PendingStreamCheckpoint {
+  detectedAt: number
+}
+
 interface ChatStore {
   conversations: Conversation[]
   activeConversationId: string | null
   messages: Message[]
+  conversationStreams: Record<string, ConversationStreamState>
+  interruptedConversations: Record<string, InterruptedConversationState>
   isStreaming: boolean
   streamingContent: string
   streamingToolCalls: ToolCall[]
@@ -133,7 +161,7 @@ interface ChatStore {
   createConversation: (providerId: string, model: string) => Promise<string>
   setActiveConversation: (id: string | null) => Promise<void>
   sendMessage: (content: string, providerId: string, model: string, attachments?: MessageAttachment[]) => Promise<void>
-  queueMessage: (content: string, providerId: string, model: string, attachments?: MessageAttachment[]) => void
+  queueMessage: (content: string, providerId: string, model: string, attachments?: MessageAttachment[], conversationId?: string | null) => void
   processQueue: () => Promise<void>
   stopStreaming: () => Promise<void>
   deleteConversation: (id: string) => Promise<void>
@@ -142,13 +170,93 @@ interface ChatStore {
   handleModeSwitch: (fromMode: AgentMode, toMode: AgentMode, reason: string) => void
   clearError: () => void
   regenerateLastResponse: (providerId: string, model: string) => Promise<void>
+  resumeInterruptedConversation: (conversationId?: string) => Promise<void>
+  dismissInterruptedConversation: (conversationId?: string) => void
   addSystemNotification: (notification: Omit<SystemNotification, 'id' | 'timestamp'>) => void
   clearSystemNotifications: () => void
   setConversationWorkspaceId: (id: string, workspaceId: string | null) => void
+  getRegenerateArtifactImpact: () => { artifacts: Array<{ id: string; title: string; type: string }> }
 }
 
-let currentStreamChannelId: string | null = null
+const streamChannelByConversation = new Map<string, string>()
 let modeTransitionTimeoutId: ReturnType<typeof setTimeout> | null = null
+const PENDING_STREAMS_STORAGE_KEY = 'jelico.pending_streams.v1'
+
+function readPendingStreamCheckpoints(): Record<string, PendingStreamCheckpoint> {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return {}
+    }
+    const raw = window.localStorage.getItem(PENDING_STREAMS_STORAGE_KEY)
+    if (!raw) return {}
+
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+
+    const entries = Object.entries(parsed).filter(([conversationId, value]) => {
+      if (!conversationId || typeof conversationId !== 'string') return false
+      if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+      const checkpoint = value as Record<string, unknown>
+      return (
+        typeof checkpoint.providerId === 'string' &&
+        typeof checkpoint.model === 'string' &&
+        typeof checkpoint.startedAt === 'number'
+      )
+    }) as Array<[string, PendingStreamCheckpoint]>
+
+    return Object.fromEntries(entries)
+  } catch {
+    return {}
+  }
+}
+
+function writePendingStreamCheckpoints(checkpoints: Record<string, PendingStreamCheckpoint>) {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return
+    }
+    window.localStorage.setItem(PENDING_STREAMS_STORAGE_KEY, JSON.stringify(checkpoints))
+  } catch {
+    // Ignore localStorage write failures
+  }
+}
+
+function getPendingStreamCheckpoint(conversationId: string): PendingStreamCheckpoint | null {
+  return readPendingStreamCheckpoints()[conversationId] || null
+}
+
+function setPendingStreamCheckpoint(conversationId: string, checkpoint: PendingStreamCheckpoint) {
+  const checkpoints = readPendingStreamCheckpoints()
+  checkpoints[conversationId] = checkpoint
+  writePendingStreamCheckpoints(checkpoints)
+}
+
+function clearPendingStreamCheckpoint(conversationId: string) {
+  const checkpoints = readPendingStreamCheckpoints()
+  if (!checkpoints[conversationId]) return
+  delete checkpoints[conversationId]
+  writePendingStreamCheckpoints(checkpoints)
+}
+
+function getLatestUnansweredUserMessage(messages: Message[]): Message | null {
+  let lastAssistantIndex = -1
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i].role === 'assistant') {
+      lastAssistantIndex = i
+      break
+    }
+  }
+
+  for (let i = messages.length - 1; i > lastAssistantIndex; i -= 1) {
+    if (messages[i].role === 'user') {
+      return messages[i]
+    }
+  }
+
+  return null
+}
 
 function getRestoredTokenCount(messages: Message[]): number {
   if (messages.length === 0) return 0
@@ -166,10 +274,132 @@ function getRestoredTokenCount(messages: Message[]): number {
   return messages.reduce((sum, msg) => sum + estimateTokens(msg.content || ''), 0)
 }
 
+function getLastAssistantAndUser(messages: Message[]): {
+  lastAssistantIndex: number
+  lastAssistant: Message | null
+  lastUser: Message | null
+} {
+  let lastAssistantIndex = -1
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i].role === 'assistant') {
+      lastAssistantIndex = i
+      break
+    }
+  }
+
+  if (lastAssistantIndex === -1) {
+    return { lastAssistantIndex, lastAssistant: null, lastUser: null }
+  }
+
+  let lastUser: Message | null = null
+  for (let i = lastAssistantIndex - 1; i >= 0; i -= 1) {
+    if (messages[i].role === 'user') {
+      lastUser = messages[i]
+      break
+    }
+  }
+
+  return {
+    lastAssistantIndex,
+    lastAssistant: messages[lastAssistantIndex] || null,
+    lastUser,
+  }
+}
+
+function getArtifactsCreatedByLastAssistantTurn(
+  activeConversationId: string | null,
+  messages: Message[],
+  artifacts: Artifact[]
+): Artifact[] {
+  if (!activeConversationId || messages.length < 2) return []
+
+  const { lastAssistant, lastUser } = getLastAssistantAndUser(messages)
+  if (!lastAssistant || !lastUser) return []
+
+  const createCalls = (lastAssistant.toolCalls || [])
+    .filter((tc) => tc.name === 'create_artifact')
+    .map((tc) => ({
+      title: typeof tc.args?.title === 'string' ? tc.args.title : undefined,
+      type: typeof tc.args?.type === 'string' ? tc.args.type.toLowerCase() : undefined,
+    }))
+
+  if (createCalls.length === 0) return []
+
+  const candidates = artifacts
+    .filter((artifact) =>
+      artifact.conversationId === activeConversationId &&
+      artifact.createdAt > lastUser.createdAt
+    )
+    .sort((a, b) => b.createdAt - a.createdAt)
+
+  if (candidates.length === 0) return []
+
+  const usedIds = new Set<string>()
+  const matched: Artifact[] = []
+
+  for (const call of createCalls) {
+    const callTitle = call.title?.trim().toLowerCase()
+    const callType = call.type
+
+    const hit = candidates.find((artifact) => {
+      if (usedIds.has(artifact.id)) return false
+      const typeMatches = callType ? artifact.type.toLowerCase() === callType : true
+      const titleMatches = callTitle ? artifact.title.trim().toLowerCase() === callTitle : true
+      return typeMatches && titleMatches
+    })
+
+    if (hit) {
+      usedIds.add(hit.id)
+      matched.push(hit)
+    }
+  }
+
+  // Fallback when model omitted/mangled title args: best-effort newest artifacts from this turn.
+  if (matched.length === 0) {
+    return candidates.slice(0, createCalls.length)
+  }
+
+  return matched
+}
+
+function createEmptyConversationStreamState(): ConversationStreamState {
+  return {
+    isStreaming: false,
+    streamingContent: '',
+    streamingToolCalls: [],
+    streamingToolResults: [],
+    streamingSegments: [],
+    statusDisplayQueue: [],
+    toolInputProgress: null,
+    isReasoning: false,
+    reasoningContent: '',
+    streamingStartTime: null,
+    lastCompletedTool: null,
+  }
+}
+
+function projectStreamStateToActiveFields(streamState: ConversationStreamState) {
+  return {
+    isStreaming: streamState.isStreaming,
+    streamingContent: streamState.streamingContent,
+    streamingToolCalls: streamState.streamingToolCalls,
+    streamingToolResults: streamState.streamingToolResults,
+    streamingSegments: streamState.streamingSegments,
+    statusDisplayQueue: streamState.statusDisplayQueue,
+    toolInputProgress: streamState.toolInputProgress,
+    isReasoning: streamState.isReasoning,
+    reasoningContent: streamState.reasoningContent,
+    streamingStartTime: streamState.streamingStartTime,
+    lastCompletedTool: streamState.lastCompletedTool,
+  }
+}
+
 export const useChatStore = create<ChatStore>((set, get) => ({
   conversations: [],
   activeConversationId: null,
   messages: [],
+  conversationStreams: {},
+  interruptedConversations: {},
   modeTransitioning: false,
   modeSwitchReason: null,
   lastCompletedTool: null,
@@ -239,19 +469,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       set({
         activeConversationId: null,
         messages: [],
-        isStreaming: false,
-        streamingStartTime: null,
-        streamingContent: '',
-        streamingToolCalls: [],
-        streamingToolResults: [],
-        streamingSegments: [],
-        statusDisplayQueue: [],
-        toolInputProgress: null,
         modeTransitioning: false,
         modeSwitchReason: null,
-        isReasoning: false,
-        reasoningContent: '',
         error: null,
+        ...projectStreamStateToActiveFields(createEmptyConversationStreamState()),
       })
       // New Chat: keep current workspace selection (user can switch to Sandbox explicitly)
       // No conversation = no artifacts to show
@@ -264,23 +485,46 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       const conversation = await window.jelico.conversations.get(id)
       const loadedMessages = conversation?.messages || []
 
-      set({
-        activeConversationId: id,
-        messages: loadedMessages,
-        isLoading: false,
-        // Clear streaming state when switching to prevent old stream data appearing
-        isStreaming: false,
-        streamingContent: '',
-        streamingToolCalls: [],
-        streamingToolResults: [],
-        streamingSegments: [],
-        statusDisplayQueue: [],
-        toolInputProgress: null,
-        modeTransitioning: false,
-        modeSwitchReason: null,
-        isReasoning: false,
-        reasoningContent: '',
+      set((state) => {
+        const streamState = state.conversationStreams[id] || createEmptyConversationStreamState()
+        return {
+          activeConversationId: id,
+          messages: loadedMessages,
+          isLoading: false,
+          modeTransitioning: false,
+          modeSwitchReason: null,
+          ...projectStreamStateToActiveFields(streamState),
+        }
       })
+
+      const activeStreamState = get().conversationStreams[id]
+      const pendingCheckpoint = getPendingStreamCheckpoint(id)
+      const unansweredUser = getLatestUnansweredUserMessage(loadedMessages)
+
+      if (pendingCheckpoint && !streamChannelByConversation.has(id) && !activeStreamState?.isStreaming && unansweredUser) {
+        set((state) => {
+          if (state.interruptedConversations[id]) return {}
+          return {
+            interruptedConversations: {
+              ...state.interruptedConversations,
+              [id]: {
+                ...pendingCheckpoint,
+                detectedAt: Date.now(),
+              },
+            },
+          }
+        })
+      } else {
+        set((state) => {
+          const { [id]: _removed, ...rest } = state.interruptedConversations
+          return { interruptedConversations: rest }
+        })
+
+        // Remove stale checkpoints when there is nothing to resume.
+        if (pendingCheckpoint && !unansweredUser) {
+          clearPendingStreamCheckpoint(id)
+        }
+      }
 
       // Ensure context usage survives conversation reloads.
       if (conversation) {
@@ -325,13 +569,22 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 
   // Internal flag to track if this is a regenerate (skips adding user message)
-  sendMessage: async (content, providerId, model, attachments, _isRegenerate = false) => {
-    const { activeConversationId, messages, mode, isStreaming } = get()
-    const { isCompacting } = useContextStore.getState()
+  sendMessage: async (content, providerId, model, attachments, _isRegenerate = false, _forcedConversationId: string | null = null) => {
+    const { activeConversationId, messages, mode } = get()
+    const requestedConversationId = _forcedConversationId ?? activeConversationId
+    const contextStore = useContextStore.getState()
 
-    // If already streaming or compacting, queue the message (unless regenerating)
-    if ((isStreaming || isCompacting) && !_isRegenerate) {
-      get().queueMessage(content, providerId, model, attachments)
+    const activeStreamState = requestedConversationId
+      ? get().conversationStreams[requestedConversationId]
+      : undefined
+
+    const compactingActiveConversation =
+      requestedConversationId !== null &&
+      contextStore.isConversationCompacting(requestedConversationId)
+
+    // If this conversation is already streaming or compacting, queue the message (unless regenerating)
+    if (((activeStreamState?.isStreaming ?? false) || compactingActiveConversation) && !_isRegenerate) {
+      get().queueMessage(content, providerId, model, attachments, requestedConversationId)
       return
     }
 
@@ -349,7 +602,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       }
     }
 
-    let conversationId = activeConversationId
+    let conversationId = requestedConversationId
 
     // Create conversation if needed (never happens during regenerate)
     if (!conversationId) {
@@ -364,8 +617,50 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       }
     }
 
+    if (!conversationId) return
+
+    const targetConversationId = conversationId
+    const updateConversationStreamState = (updater: (current: ConversationStreamState) => ConversationStreamState) => {
+      set((state) => {
+        const current = state.conversationStreams[targetConversationId] || createEmptyConversationStreamState()
+        const next = updater(current)
+        const nextConversationStreams = {
+          ...state.conversationStreams,
+          [targetConversationId]: next,
+        }
+
+        if (state.activeConversationId !== targetConversationId) {
+          return { conversationStreams: nextConversationStreams }
+        }
+
+        return {
+          conversationStreams: nextConversationStreams,
+          ...projectStreamStateToActiveFields(next),
+        }
+      })
+    }
+
+    const clearConversationStreamState = () => {
+      set((state) => {
+        const { [targetConversationId]: _removed, ...rest } = state.conversationStreams
+        if (state.activeConversationId !== targetConversationId) {
+          return { conversationStreams: rest }
+        }
+        return {
+          conversationStreams: rest,
+          ...projectStreamStateToActiveFields(createEmptyConversationStreamState()),
+        }
+      })
+    }
+
+    let contextMessages = messages
+    if (targetConversationId !== activeConversationId) {
+      const conversation = await window.jelico.conversations.get(targetConversationId)
+      contextMessages = conversation?.messages || []
+    }
+
     // For regenerate, use existing messages; otherwise add user message
-    let updatedMessages = messages
+    let updatedMessages = contextMessages
     if (!_isRegenerate) {
       // Add user message (show original content, not expanded skill)
       const userMessage = await window.jelico.conversations.addMessage(conversationId, {
@@ -376,7 +671,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
       // Update title if this is the first message - use truncated content or placeholder
       // AI will generate a proper title in the background
-      if (messages.length === 0) {
+      if (contextMessages.length === 0) {
         // Truncate to 50 chars max for initial display (AI generates better title)
         let titleSource = content.trim().slice(0, 50) + (content.trim().length > 50 ? '...' : '')
 
@@ -439,22 +734,32 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         })
       }
 
-      updatedMessages = [...messages, userMessage]
-      set({ messages: updatedMessages })
+      updatedMessages = [...contextMessages, userMessage]
+      set((state) => (
+        state.activeConversationId === targetConversationId
+          ? { messages: updatedMessages }
+          : {}
+      ))
     }
 
-    // Set streaming state
-    set({
+    const streamStartedAt = Date.now()
+
+    // Set streaming state for this conversation
+    updateConversationStreamState(() => ({
+      ...createEmptyConversationStreamState(),
       isStreaming: true,
-      streamingStartTime: Date.now(),
-      streamingContent: '',
-      streamingToolCalls: [],
-      streamingToolResults: [],
-      streamingSegments: [],
-      statusDisplayQueue: [],
-      toolInputProgress: null,
-      isReasoning: false,
-      reasoningContent: '',
+      streamingStartTime: streamStartedAt,
+    }))
+
+    set((state) => {
+      const { [targetConversationId]: _removedInterrupted, ...restInterrupted } = state.interruptedConversations
+      return { interruptedConversations: restInterrupted }
+    })
+
+    setPendingStreamCheckpoint(targetConversationId, {
+      providerId,
+      model,
+      startedAt: streamStartedAt,
     })
 
     // Get workspace path for context
@@ -488,16 +793,25 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }))
 
     // Start streaming with mode, workspace, and artifact context
-    const channelId = window.jelico.ai.stream({
-      providerId,
-      model,
-      mode: finalMode,
-      messages: aiMessages,
-      workspacePath: activeWorkspace?.path,
-      artifacts: artifactContext,
-      conversationId,  // Pass conversation ID for state isolation
-    })
-    currentStreamChannelId = channelId
+    let channelId: string
+    try {
+      channelId = window.jelico.ai.stream({
+        providerId,
+        model,
+        mode: finalMode,
+        messages: aiMessages,
+        workspacePath: activeWorkspace?.path,
+        artifacts: artifactContext,
+        conversationId: targetConversationId,  // Pass conversation ID for state isolation
+      })
+    } catch (error: any) {
+      console.error('[Chat Store] Failed to start stream:', error)
+      clearPendingStreamCheckpoint(targetConversationId)
+      clearConversationStreamState()
+      set({ error: error?.message || 'Failed to start AI stream' })
+      return
+    }
+    streamChannelByConversation.set(targetConversationId, channelId)
 
     let fullContent = ''
     const streamStartTime = Date.now()
@@ -514,9 +828,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         }
         lastChunkTime = now
         fullContent += chunk
-        set((state) => {
+        updateConversationStreamState((current) => {
           // Find or create the current text segment
-          const segments = [...state.streamingSegments]
+          const segments = [...current.streamingSegments]
           const lastSegment = segments[segments.length - 1]
 
           if (lastSegment?.type === 'text') {
@@ -531,6 +845,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           }
 
           return {
+            ...current,
             streamingContent: fullContent,
             streamingSegments: segments,
           }
@@ -543,19 +858,39 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     window.jelico.ai.onToolCalls(channelId, (toolCalls) => {
       console.log('[Chat Store] Received tool calls:', toolCalls)
       const now = Date.now()
-      set((state) => {
+      updateConversationStreamState((current) => {
+        // If a text segment ends with a colon, drop it to avoid "text:" before tool calls
+        const segments = [...current.streamingSegments]
+        const lastSegment = segments[segments.length - 1]
+        if (lastSegment?.type === 'text') {
+          const trimmed = lastSegment.content.replace(/[ \t]+$/g, '')
+          if (trimmed.endsWith(':')) {
+            segments[segments.length - 1] = {
+              type: 'text',
+              content: trimmed.slice(0, -1),
+            }
+          }
+        }
+
         // Add tool segments for each new tool call
         const newSegments: StreamingSegment[] = toolCalls.map(tc => ({
           type: 'tool' as const,
           toolCallId: tc.id,
         }))
 
+        const nextStreamingContent = segments.reduce((acc, seg) => {
+          return seg.type === 'text' ? acc + seg.content : acc
+        }, '')
+        fullContent = nextStreamingContent
+
         return {
-          streamingToolCalls: [...state.streamingToolCalls, ...toolCalls],
-          streamingSegments: [...state.streamingSegments, ...newSegments],
+          ...current,
+          streamingToolCalls: [...current.streamingToolCalls, ...toolCalls],
+          streamingSegments: [...segments, ...newSegments],
+          streamingContent: nextStreamingContent,
           // Add to status display queue for graceful UX
           statusDisplayQueue: [
-            ...state.statusDisplayQueue,
+            ...current.statusDisplayQueue,
             ...toolCalls.map(tc => ({
               id: tc.id,
               toolName: tc.name,
@@ -572,19 +907,19 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       console.log('[Chat Store] Received tool results:', toolResults)
       const now = Date.now()
 
-      set((state) => {
+      updateConversationStreamState((current) => {
         // Update tool call statuses to 'complete' when their results arrive
         const completedIds = new Set(toolResults.map(r => r.toolCallId))
-        const updatedToolCalls = state.streamingToolCalls.map((tc) =>
+        const updatedToolCalls = current.streamingToolCalls.map((tc) =>
           completedIds.has(tc.id) ? { ...tc, status: 'complete' as const } : tc
         )
 
         // Track the last completed tool for status line display
         const lastResult = toolResults[toolResults.length - 1]
-        const completedToolCall = state.streamingToolCalls.find(tc => tc.id === lastResult?.toolCallId)
+        const completedToolCall = current.streamingToolCalls.find(tc => tc.id === lastResult?.toolCallId)
 
         // Update status display queue - mark items as completed but keep for minimum display time
-        const updatedQueue = state.statusDisplayQueue.map(item => {
+        const updatedQueue = current.statusDisplayQueue.map(item => {
           if (completedIds.has(item.id) && !item.completedAt) {
             return { ...item, completedAt: now }
           }
@@ -592,14 +927,15 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         })
 
         return {
+          ...current,
           streamingToolCalls: updatedToolCalls,
-          streamingToolResults: [...state.streamingToolResults, ...toolResults],
+          streamingToolResults: [...current.streamingToolResults, ...toolResults],
           statusDisplayQueue: updatedQueue,
           lastCompletedTool: completedToolCall ? {
             name: completedToolCall.name,
             args: completedToolCall.args,
             completedAt: now,
-          } : state.lastCompletedTool,
+          } : current.lastCompletedTool,
           // Clear tool input progress when tool completes - fixes status stuck on "Generating spawn_agent"
           toolInputProgress: null,
         }
@@ -609,8 +945,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     // Handle tool call updates - updates status and args for existing tool calls
     window.jelico.ai.onToolCallUpdate(channelId, (update) => {
       console.log('[Chat Store] Tool call update:', update)
-      set((state) => ({
-        streamingToolCalls: state.streamingToolCalls.map((tc) =>
+      updateConversationStreamState((current) => ({
+        ...current,
+        streamingToolCalls: current.streamingToolCalls.map((tc) =>
           tc.id === update.id
             ? { ...tc, args: update.args, status: update.status }
             : tc
@@ -628,7 +965,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         useArtifactStore.getState().clearStreamingPreview()
 
         const newArtifact = await useArtifactStore.getState().addArtifact({
-          conversationId: conversationId!,
+          conversationId: targetConversationId,
           type: artifact.type,
           title: artifact.title,
           content: artifact.content,
@@ -666,7 +1003,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         displayName: agent.displayName,  // Friendly name like "Maya: Creating Wordle"
         task: agent.task,
         mode: agent.mode,
-        conversationId,  // Track which conversation this agent belongs to
+        conversationId: targetConversationId,  // Track which conversation this agent belongs to
       })
     })
 
@@ -710,22 +1047,33 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     // Handle tool input progress (for large artifacts)
     window.jelico.ai.onToolInputProgress(channelId, (progress) => {
-      set({ toolInputProgress: progress })
+      updateConversationStreamState((current) => ({
+        ...current,
+        toolInputProgress: progress,
+      }))
     })
 
     // Handle reasoning/thinking events for thinking models (Kimi K2.5, o1, o3, etc.)
     window.jelico.ai.onReasoningStart(channelId, () => {
-      set({ isReasoning: true, reasoningContent: '' })
+      updateConversationStreamState((current) => ({
+        ...current,
+        isReasoning: true,
+        reasoningContent: '',
+      }))
     })
 
     window.jelico.ai.onReasoning(channelId, (data) => {
-      set((state) => ({
-        reasoningContent: state.reasoningContent + data.content,
+      updateConversationStreamState((current) => ({
+        ...current,
+        reasoningContent: current.reasoningContent + data.content,
       }))
     })
 
     window.jelico.ai.onReasoningEnd(channelId, () => {
-      set({ isReasoning: false })
+      updateConversationStreamState((current) => ({
+        ...current,
+        isReasoning: false,
+      }))
       // Note: reasoningContent is preserved until stream ends so UI can display it
     })
 
@@ -738,9 +1086,15 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     // Handle stream end
     window.jelico.ai.onStreamEnd(channelId, async (stats) => {
       window.jelico.ai.removeListeners(channelId)
-      currentStreamChannelId = null
+      const activeChannel = streamChannelByConversation.get(targetConversationId)
+      if (activeChannel === channelId) {
+        streamChannelByConversation.delete(targetConversationId)
+      }
+      clearPendingStreamCheckpoint(targetConversationId)
 
-      const { streamingToolCalls, streamingToolResults } = get()
+      const streamSnapshot = get().conversationStreams[targetConversationId] || createEmptyConversationStreamState()
+      const streamingToolCalls = streamSnapshot.streamingToolCalls
+      const streamingToolResults = streamSnapshot.streamingToolResults
       const totalDurationMs = Date.now() - streamStartTime
       // Calculate actual generation time (first chunk to last chunk)
       // This excludes tool execution time and gives accurate tok/s
@@ -765,20 +1119,24 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           }
         }
 
-        // Save assistant message with tool calls/results - even if content is empty
-        const assistantMessage = await window.jelico.conversations.addMessage(conversationId!, {
+        const hasToolActivity = streamingToolCalls.length > 0 || streamingToolResults.length > 0
+        const assistantContent = fullContent && fullContent.trim().length > 0
+          ? fullContent
+          : (hasToolActivity ? 'Completed requested tool actions.' : 'No response text was returned.')
+
+        // Save assistant message with tool calls/results
+        const assistantMessage = await window.jelico.conversations.addMessage(targetConversationId, {
           role: 'assistant',
-          content: fullContent || '(Used tools)', // Ensure non-empty for DB
+          content: assistantContent,
           toolCalls: streamingToolCalls.length > 0 ? streamingToolCalls : undefined,
           toolResults: streamingToolResults.length > 0 ? streamingToolResults : undefined,
           usage,
         })
 
         // Attach usage to the message object for display
-        // Restore original content (could be empty) for display
         const messageWithTools: Message = {
           ...assistantMessage,
-          content: fullContent, // Keep original empty if it was empty
+          content: assistantContent,
           usage,
         }
 
@@ -790,46 +1148,40 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         })
 
         // Update context window token count from actual usage
-        if (conversationId && usage?.totalTokens) {
-          useContextStore.getState().updateTokenCount(conversationId, usage.totalTokens)
-        } else if (conversationId) {
+        if (usage?.totalTokens) {
+          useContextStore.getState().updateTokenCount(targetConversationId, usage.totalTokens)
+        } else {
           // No fallback estimation - we need actual token counts from the API
           console.warn('[Chat Store] No usage stats received from provider - context tracking requires API to report token usage')
         }
 
-        set((state) => ({
-          messages: [...state.messages, messageWithTools],
-          isStreaming: false,
-          streamingStartTime: null,
-          streamingContent: '',
-          streamingToolCalls: [],
-          streamingToolResults: [],
-          streamingSegments: [],
-          statusDisplayQueue: [],
-          toolInputProgress: null,
-          isReasoning: false,
-          reasoningContent: '',
-          lastCompletedTool: null,
-        }))
+        set((state) => {
+          const nextMessages = state.activeConversationId === targetConversationId
+            ? [...state.messages, messageWithTools]
+            : state.messages
+
+          const { [targetConversationId]: _removed, ...restStreams } = state.conversationStreams
+          const { [targetConversationId]: _removedInterrupted, ...restInterrupted } = state.interruptedConversations
+          const updates: Partial<ChatStore> = {
+            messages: nextMessages,
+            conversationStreams: restStreams,
+            interruptedConversations: restInterrupted,
+          }
+
+          if (state.activeConversationId === targetConversationId) {
+            Object.assign(updates, projectStreamStateToActiveFields(createEmptyConversationStreamState()))
+          }
+
+          return updates as Partial<ChatStore>
+        })
 
         // Title is generated ONCE when user sends first message (see sendMessage)
         // No second generation here - we don't want AI response to change the title
       } catch (error) {
         console.error('[Chat Store] Error in onStreamEnd:', error)
         // Still need to end streaming state even on error
-        set({
-          isStreaming: false,
-          streamingStartTime: null,
-          streamingContent: '',
-          streamingToolCalls: [],
-          streamingToolResults: [],
-          streamingSegments: [],
-          statusDisplayQueue: [],
-          lastCompletedTool: null,
-          isReasoning: false,
-          reasoningContent: '',
-          error: `Failed to save message: ${error}`,
-        })
+        clearConversationStreamState()
+        set({ error: `Failed to save message: ${error}` })
       }
 
       // Add system notification for created artifacts
@@ -841,46 +1193,46 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       }
 
       // Check context usage and trigger compaction if needed
-      if (conversationId) {
-        const contextStore = useContextStore.getState()
-        const contextUsage = contextStore.getContextUsage(conversationId)
+      const contextStore = useContextStore.getState()
+      const contextUsage = contextStore.getContextUsage(targetConversationId)
 
-        if (contextUsage.shouldCompact && contextStore.autoCompact) {
-          // Start compaction - set flag to block new messages
-          contextStore.setIsCompacting(true)
+      if (contextUsage.shouldCompact && contextStore.autoCompact) {
+        // Start compaction for this conversation only.
+        contextStore.setConversationCompacting(targetConversationId, true)
 
-          // Run compaction async
-          window.jelico.compaction.compact({
-            conversationId,
-            providerId,
-            model,
-          }).then(async (result) => {
-            if (result.success) {
-              // Update context with new token count
-              if (result.tokensAfter !== undefined) {
-                contextStore.updateTokenCount(conversationId, result.tokensAfter)
-              }
-
-              // Show compaction complete notification
-              get().addSystemNotification({
-                type: 'compaction_complete',
-              })
-
-              // Reload messages to get the compacted version
-              await get().setActiveConversation(conversationId)
-            } else {
-              console.error('[Chat] Compaction failed:', result.error)
+        // Run compaction async
+        window.jelico.compaction.compact({
+          conversationId: targetConversationId,
+          providerId,
+          model,
+        }).then(async (result) => {
+          if (result.success) {
+            // Update context with new token count
+            if (result.tokensAfter !== undefined) {
+              contextStore.updateTokenCount(targetConversationId, result.tokensAfter)
             }
 
-            // Clear compacting flag and process any queued messages
-            contextStore.setIsCompacting(false)
-            get().processQueue()
-          }).catch((error) => {
-            console.error('[Chat] Compaction error:', error)
-            contextStore.setIsCompacting(false)
-            get().processQueue()
-          })
-        }
+            // Show compaction complete notification
+            get().addSystemNotification({
+              type: 'compaction_complete',
+            })
+
+            // Reload messages only if this conversation is currently visible.
+            if (get().activeConversationId === targetConversationId) {
+              await get().setActiveConversation(targetConversationId)
+            }
+          } else {
+            console.error('[Chat] Compaction failed:', result.error)
+          }
+
+          // Clear compacting flag for this conversation and process queued messages.
+          contextStore.setConversationCompacting(targetConversationId, false)
+          get().processQueue()
+        }).catch((error) => {
+          console.error('[Chat] Compaction error:', error)
+          contextStore.setConversationCompacting(targetConversationId, false)
+          get().processQueue()
+        })
       }
 
       // Process any queued messages
@@ -890,23 +1242,22 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     // Handle stream error
     window.jelico.ai.onStreamError(channelId, (error) => {
       window.jelico.ai.removeListeners(channelId)
-      currentStreamChannelId = null
+      const activeChannel = streamChannelByConversation.get(targetConversationId)
+      if (activeChannel === channelId) {
+        streamChannelByConversation.delete(targetConversationId)
+      }
+      clearPendingStreamCheckpoint(targetConversationId)
 
       // Clear streaming preview to prevent stale artifact content
       useArtifactStore.getState().clearStreamingPreview()
 
-      set({
-        isStreaming: false,
-        streamingStartTime: null,
-        streamingContent: '',
-        streamingToolCalls: [],
-        streamingToolResults: [],
-        streamingSegments: [],
-        statusDisplayQueue: [],
-        toolInputProgress: null,
-        isReasoning: false,
-        reasoningContent: '',
-        error: error,
+      clearConversationStreamState()
+      set((state) => {
+        const { [targetConversationId]: _removedInterrupted, ...restInterrupted } = state.interruptedConversations
+        return {
+          interruptedConversations: restInterrupted,
+          error,
+        }
       })
 
       // Still try to process queue on error
@@ -914,9 +1265,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     })
   },
 
-  queueMessage: (content, providerId, model, attachments) => {
+  queueMessage: (content, providerId, model, attachments, conversationId) => {
     set((state) => ({
-      messageQueue: [...state.messageQueue, { content, attachments, providerId, model }],
+      messageQueue: [...state.messageQueue, { content, attachments, providerId, model, conversationId }],
     }))
   },
 
@@ -929,17 +1280,27 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set({ messageQueue: remaining })
 
     // Send the queued message
-    await get().sendMessage(nextMessage.content, nextMessage.providerId, nextMessage.model, nextMessage.attachments)
+    await (get().sendMessage as any)(
+      nextMessage.content,
+      nextMessage.providerId,
+      nextMessage.model,
+      nextMessage.attachments,
+      false,
+      nextMessage.conversationId ?? null
+    )
   },
 
   stopStreaming: async () => {
+    const { activeConversationId, conversationStreams } = get()
+    if (!activeConversationId) return
+
+    const streamState = conversationStreams[activeConversationId] || createEmptyConversationStreamState()
     const {
       streamingContent,
       streamingToolCalls,
       streamingToolResults,
       streamingSegments,
-      activeConversationId,
-    } = get()
+    } = streamState
 
     // Debug: Log what we have when stop is called
     console.log('[Chat Store] stopStreaming called:', {
@@ -953,11 +1314,13 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       conversationId: activeConversationId,
     })
 
-    if (currentStreamChannelId) {
-      window.jelico.ai.stopStream(currentStreamChannelId)
-      window.jelico.ai.removeListeners(currentStreamChannelId)
-      currentStreamChannelId = null
+    const streamChannelId = streamChannelByConversation.get(activeConversationId)
+    if (streamChannelId) {
+      window.jelico.ai.stopStream(streamChannelId)
+      window.jelico.ai.removeListeners(streamChannelId)
+      streamChannelByConversation.delete(activeConversationId)
     }
+    clearPendingStreamCheckpoint(activeConversationId)
 
     // Clear streaming preview to prevent stale artifact content
     useArtifactStore.getState().clearStreamingPreview()
@@ -995,22 +1358,27 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       console.log('[Chat Store] Nothing to save on stop - no content or tool calls')
     }
 
-    set({
-      isStreaming: false,
-      streamingStartTime: null,
-      streamingContent: '',
-      streamingToolCalls: [],
-      streamingToolResults: [],
-      streamingSegments: [],
-      statusDisplayQueue: [],
-      toolInputProgress: null,
-      isReasoning: false,
-      reasoningContent: '',
+    set((state) => {
+      const { [activeConversationId]: _removed, ...restStreams } = state.conversationStreams
+      const { [activeConversationId]: _removedInterrupted, ...restInterrupted } = state.interruptedConversations
+      return {
+        conversationStreams: restStreams,
+        interruptedConversations: restInterrupted,
+        ...projectStreamStateToActiveFields(createEmptyConversationStreamState()),
+      }
     })
   },
 
   deleteConversation: async (id) => {
     try {
+      const streamChannelId = streamChannelByConversation.get(id)
+      if (streamChannelId) {
+        window.jelico.ai.stopStream(streamChannelId)
+        window.jelico.ai.removeListeners(streamChannelId)
+        streamChannelByConversation.delete(id)
+      }
+      clearPendingStreamCheckpoint(id)
+
       // Delete artifacts for this conversation
       await useArtifactStore.getState().clearConversationArtifacts(id)
 
@@ -1027,21 +1395,27 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
       if (activeConversationId === id) {
         // Clear all state when deleting the active conversation
+        const { [id]: _removedStream, ...restStreams } = get().conversationStreams
+        const { [id]: _removedInterrupted, ...restInterrupted } = get().interruptedConversations
         set({
           conversations,
           activeConversationId: null,
           messages: [],
-          isStreaming: false,
-          streamingStartTime: null,
-          streamingContent: '',
-          streamingToolCalls: [],
-          streamingToolResults: [],
-          streamingSegments: [],
-          statusDisplayQueue: [],
+          conversationStreams: restStreams,
+          interruptedConversations: restInterrupted,
+          ...projectStreamStateToActiveFields(createEmptyConversationStreamState()),
           error: null,
         })
       } else {
-        set({ conversations })
+        set((state) => {
+          const { [id]: _removedStream, ...restStreams } = state.conversationStreams
+          const { [id]: _removedInterrupted, ...restInterrupted } = state.interruptedConversations
+          return {
+            conversations,
+            conversationStreams: restStreams,
+            interruptedConversations: restInterrupted,
+          }
+        })
       }
     } catch (error: any) {
       set({ error: error.message })
@@ -1081,36 +1455,18 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     if (isStreaming || !activeConversationId || messages.length < 2) return
 
-    // Find the last assistant message
-    let lastAssistantIndex = -1
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role === 'assistant') {
-        lastAssistantIndex = i
-        break
-      }
-    }
+    const { lastAssistantIndex, lastUser } = getLastAssistantAndUser(messages)
+    if (lastAssistantIndex === -1 || !lastUser) return
 
-    if (lastAssistantIndex === -1) return
-
-    // Find the user message before the assistant message
-    let lastUserMessage: Message | null = null
-    for (let i = lastAssistantIndex - 1; i >= 0; i--) {
-      if (messages[i].role === 'user') {
-        lastUserMessage = messages[i]
-        break
-      }
-    }
-
-    if (!lastUserMessage) return
-
-    // Remove artifacts created during this turn
-    // We identify them by looking at artifacts created after the user message
+    // Remove artifacts created during this turn (create_artifact calls only)
     const artifactStore = useArtifactStore.getState()
-    const artifacts = artifactStore.artifacts.filter(
-      a => a.conversationId === activeConversationId &&
-           a.createdAt > lastUserMessage!.createdAt
+    const artifactsToDelete = getArtifactsCreatedByLastAssistantTurn(
+      activeConversationId,
+      messages,
+      artifactStore.artifacts
     )
-    for (const artifact of artifacts) {
+
+    for (const artifact of artifactsToDelete) {
       await artifactStore.removeArtifact(artifact.id)
     }
 
@@ -1127,7 +1483,83 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     // Start streaming with existing messages (don't re-add user message)
     // The _isRegenerate flag tells sendMessage to skip adding user message
-    await (get().sendMessage as any)(lastUserMessage.content, providerId, model, undefined, true)
+    await (get().sendMessage as any)(lastUser.content, providerId, model, undefined, true)
+  },
+
+  getRegenerateArtifactImpact: () => {
+    const { messages, activeConversationId } = get()
+    if (!activeConversationId || messages.length < 2) {
+      return { artifacts: [] }
+    }
+
+    const artifacts = getArtifactsCreatedByLastAssistantTurn(
+      activeConversationId,
+      messages,
+      useArtifactStore.getState().artifacts
+    )
+
+    return {
+      artifacts: artifacts.map((artifact) => ({
+        id: artifact.id,
+        title: artifact.title,
+        type: artifact.type,
+      })),
+    }
+  },
+
+  resumeInterruptedConversation: async (conversationId) => {
+    const targetConversationId = conversationId || get().activeConversationId
+    if (!targetConversationId) return
+
+    const streamState = get().conversationStreams[targetConversationId]
+    if (streamState?.isStreaming) return
+
+    try {
+      const conversation = await window.jelico.conversations.get(targetConversationId)
+      if (!conversation) return
+
+      const pendingCheckpoint = getPendingStreamCheckpoint(targetConversationId)
+      const unansweredUser = getLatestUnansweredUserMessage(conversation.messages || [])
+
+      if (!unansweredUser) {
+        clearPendingStreamCheckpoint(targetConversationId)
+        set((state) => {
+          const { [targetConversationId]: _removed, ...rest } = state.interruptedConversations
+          return { interruptedConversations: rest }
+        })
+        return
+      }
+
+      const providerId = pendingCheckpoint?.providerId || conversation.providerId
+      const model = pendingCheckpoint?.model || conversation.model
+
+      set((state) => {
+        const { [targetConversationId]: _removed, ...rest } = state.interruptedConversations
+        return { interruptedConversations: rest }
+      })
+
+      await (get().sendMessage as any)(
+        unansweredUser.content,
+        providerId,
+        model,
+        unansweredUser.attachments,
+        true,
+        targetConversationId
+      )
+    } catch (error: any) {
+      set({ error: error.message || String(error) })
+    }
+  },
+
+  dismissInterruptedConversation: (conversationId) => {
+    const targetConversationId = conversationId || get().activeConversationId
+    if (!targetConversationId) return
+
+    clearPendingStreamCheckpoint(targetConversationId)
+    set((state) => {
+      const { [targetConversationId]: _removed, ...rest } = state.interruptedConversations
+      return { interruptedConversations: rest }
+    })
   },
 
   addSystemNotification: (notification) => {

--- a/src/stores/context.ts
+++ b/src/stores/context.ts
@@ -28,7 +28,9 @@ interface ContextState {
   warningThreshold: number   // Default 0.70 (70%)
   autoCompact: boolean
 
-  // Compaction state
+  // Per-conversation compaction state
+  compactingConversations: Record<string, boolean>
+  // Backward-compatible aggregate flag (true if any conversation is compacting)
   isCompacting: boolean
 
   // Actions
@@ -53,7 +55,8 @@ interface ContextState {
   clearConversationContext: (conversationId: string) => void
   setAutoCompact: (enabled: boolean) => void
   setCompactionThreshold: (threshold: number) => void
-  setIsCompacting: (isCompacting: boolean) => void
+  isConversationCompacting: (conversationId: string) => boolean
+  setConversationCompacting: (conversationId: string, isCompacting: boolean) => void
 }
 
 export const useContextStore = create<ContextState>((set, get) => ({
@@ -61,6 +64,7 @@ export const useContextStore = create<ContextState>((set, get) => ({
   compactionThreshold: COMPACTION_THRESHOLDS.COMPACT,
   warningThreshold: COMPACTION_THRESHOLDS.WARNING,
   autoCompact: true,
+  compactingConversations: {},
   isCompacting: false,
 
   initConversationContext: async (conversationId, providerId, modelId) => {
@@ -170,7 +174,12 @@ export const useContextStore = create<ContextState>((set, get) => ({
   clearConversationContext: (conversationId) => {
     set((state) => {
       const { [conversationId]: _, ...rest } = state.conversationContexts
-      return { conversationContexts: rest }
+      const { [conversationId]: __, ...restCompacting } = state.compactingConversations
+      return {
+        conversationContexts: rest,
+        compactingConversations: restCompacting,
+        isCompacting: Object.values(restCompacting).some(Boolean),
+      }
     })
   },
 
@@ -178,7 +187,22 @@ export const useContextStore = create<ContextState>((set, get) => ({
 
   setCompactionThreshold: (threshold) => set({ compactionThreshold: threshold }),
 
-  setIsCompacting: (isCompacting) => set({ isCompacting }),
+  isConversationCompacting: (conversationId) => !!get().compactingConversations[conversationId],
+
+  setConversationCompacting: (conversationId, isCompacting) => {
+    set((state) => {
+      const nextCompacting = { ...state.compactingConversations }
+      if (isCompacting) {
+        nextCompacting[conversationId] = true
+      } else {
+        delete nextCompacting[conversationId]
+      }
+      return {
+        compactingConversations: nextCompacting,
+        isCompacting: Object.values(nextCompacting).some(Boolean),
+      }
+    })
+  },
 }))
 
 // Utility function to estimate tokens (rough approximation: ~4 chars per token)


### PR DESCRIPTION
## Summary
- improve streaming/tool-call UX so artifact turns show clearer sequencing and completed actions behavior
- add hidden-session artifact testing support with robust open/click/type/evaluate/extract/wait/screenshot flows
- harden artifact test click verification to require observable UI change by default
- add HTML artifact validation guardrails for malformed undefined-wrapped attributes
- require HTML self-testing by default in prompt guidance and tool descriptions
- add regenerate confirmation when artifacts will be deleted, and target cleanup to artifacts created by the regenerated assistant turn
- improve conversation-scoped state handling for compaction/streaming and related chat reliability updates
- bump version to 0.11.0 and add changelog entry

## Validation
- npx tsc --noEmit
- manual npm run dev verification during iterative testing

Fixes #7
Fixes #8
