### PR TITLE
v0.11.1: manual updater checks and explicit version status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.11.0
+**Current Version:** 0.11.1
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root
@@ -716,7 +716,8 @@ No environment variables required for basic operation. AI provider API keys are 
 - Single executable distribution for each platform
 
 ## Updates
-- Update checks run on startup and use GitHub Releases (latest non-prerelease)
+- Update checks are manual-only via Settings > Updates and use GitHub Releases (latest non-prerelease)
+- Updates panel shows Current/Latest versions and explicit status (up to date, update available, local newer)
 - Updates can be downloaded inside the app from Settings > Updates
 - Update assets come from release installers attached to GitHub Releases
 

--- a/electron/ipc/updates.ts
+++ b/electron/ipc/updates.ts
@@ -1,7 +1,11 @@
-import { ipcMain, BrowserWindow, shell } from 'electron'
+import { app, ipcMain, BrowserWindow, shell } from 'electron'
 import { checkForUpdates, downloadLatestUpdate } from '../services/updates'
 
 export function registerUpdateHandlers() {
+  ipcMain.handle('updates:currentVersion', async () => {
+    return app.getVersion()
+  })
+
   ipcMain.handle('updates:check', async () => {
     return checkForUpdates()
   })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -204,6 +204,7 @@ contextBridge.exposeInMainWorld('jelico', {
     },
   },
   updates: {
+    getCurrentVersion: () => ipcRenderer.invoke('updates:currentVersion'),
     check: () => ipcRenderer.invoke('updates:check'),
     download: () => ipcRenderer.invoke('updates:download'),
     openRelease: (url: string) => ipcRenderer.invoke('updates:openRelease', url),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ export default function App() {
   const { loadWorkspaces } = useWorkspaceStore()
   const { clearOncePermissions, loadPermissions } = usePermissionStore()
   const { loadFromStorage: loadTheme } = useThemeStore()
-  const { checkForUpdates, startListening } = useUpdateStore()
+  const { startListening, loadCurrentVersion } = useUpdateStore()
   const commandPalette = useCommandPalette()
 
   // Resizable canvas panel state
@@ -99,7 +99,7 @@ export default function App() {
 
   useEffect(() => {
     const stopListening = startListening()
-    checkForUpdates()
+    loadCurrentVersion()
     return () => stopListening()
   }, [])
 

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Settings, Presentation, Download } from 'lucide-react'
+import { Settings, Presentation } from 'lucide-react'
 import { useUIStore } from '../../stores/ui'
 import { useArtifactStore } from '../../stores/artifacts'
 import { useChatStore } from '../../stores/chat'
@@ -29,17 +29,6 @@ export function Header() {
 
       {/* Right - Canvas & Settings */}
       <div className="flex items-center gap-2">
-        {updateAvailable && (
-          <button
-            onClick={() => openSettings('general')}
-            className="p-2 rounded-md transition-colors relative text-accent hover:bg-bg-surface"
-            title="Update available"
-          >
-            <Download className="w-5 h-5" />
-            <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-accent rounded-full" />
-          </button>
-        )}
-
         {/* Canvas toggle button */}
         <button
           onClick={toggleCanvas}
@@ -61,10 +50,13 @@ export function Header() {
         {sidebarCollapsed && (
           <button
             onClick={() => openSettings()}
-            className="p-2 text-text-muted hover:text-text-primary hover:bg-bg-surface rounded-md transition-colors"
+            className="p-2 text-text-muted hover:text-text-primary hover:bg-bg-surface rounded-md transition-colors relative"
             title="Settings"
           >
             <Settings className="w-5 h-5" />
+            {updateAvailable && (
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-accent rounded-full" />
+            )}
           </button>
         )}
       </div>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useChatStore } from '../../stores/chat'
 import { useUIStore } from '../../stores/ui'
 import { useArtifactStore, type ArtifactType } from '../../stores/artifacts'
 import { useSandboxStore } from '../../stores/sandbox'
+import { useUpdateStore } from '../../stores/updates'
 import { TransferDialog } from '../Conversations/TransferDialog'
 import { BrailleLoader } from '../StatusIndicators'
 
@@ -91,6 +92,7 @@ export function Sidebar() {
   const { sidebarCollapsed, openSettings } = useUIStore()
   const { artifacts, selectArtifact, openCanvas } = useArtifactStore()
   const { loadFiles: loadSandboxFiles } = useSandboxStore()
+  const updateAvailable = useUpdateStore((state) => state.info?.isUpdateAvailable)
   // Track which conversations have their artifact trees expanded
   const [expandedConversations, setExpandedConversations] = useState<Set<string>>(new Set())
   // Track sandbox file counts per conversation (flat list for sidebar display)
@@ -388,6 +390,9 @@ export function Sidebar() {
         >
           <Settings className="w-4 h-4" />
           Settings
+          {updateAvailable && (
+            <span className="ml-auto w-2 h-2 bg-accent rounded-full" />
+          )}
         </button>
       </div>
 

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -19,10 +19,43 @@ const AGENT_MODES: { id: AgentMode; name: string; description: string }[] = [
   { id: 'review', name: 'Review', description: 'Quality assurance and feedback' },
 ]
 
+function parseSemver(version: string): [number, number, number] {
+  const cleaned = version.trim().replace(/^v/i, '')
+  const main = cleaned.split('-')[0] || cleaned
+  const parts = main.split('.')
+  return [
+    Number(parts[0]) || 0,
+    Number(parts[1]) || 0,
+    Number(parts[2]) || 0,
+  ]
+}
+
+function compareSemver(a: string, b: string): number {
+  const [aMajor, aMinor, aPatch] = parseSemver(a)
+  const [bMajor, bMinor, bPatch] = parseSemver(b)
+
+  if (aMajor !== bMajor) return aMajor > bMajor ? 1 : -1
+  if (aMinor !== bMinor) return aMinor > bMinor ? 1 : -1
+  if (aPatch !== bPatch) return aPatch > bPatch ? 1 : -1
+  return 0
+}
+
 export function GeneralSettings() {
   const { mode, colorThemeId, setMode, setColorTheme } = useThemeStore()
   const { mode: defaultMode, setMode: setDefaultMode } = useChatStore()
-  const { info, isChecking, isDownloading, downloadProgress, lastDownloadedTo, error, checkForUpdates, downloadUpdate } = useUpdateStore()
+  const { info, currentVersion, isChecking, isDownloading, downloadProgress, lastDownloadedTo, error, checkForUpdates, downloadUpdate } = useUpdateStore()
+  const versionStatus = (() => {
+    if (!info) return null
+
+    const comparison = compareSemver(info.currentVersion, info.latestVersion)
+    if (comparison < 0) {
+      return { text: 'Update available', className: 'text-accent' }
+    }
+    if (comparison > 0) {
+      return { text: 'Running newer than latest release', className: 'text-text-muted' }
+    }
+    return { text: 'Up to date', className: 'text-text-secondary' }
+  })()
 
   // User profile state (loaded from soul)
   const [userName, setUserName] = useState('')
@@ -199,15 +232,15 @@ export function GeneralSettings() {
             <div>
               <div className="font-medium text-text-primary">Version</div>
               <div className="text-sm text-text-muted">
-                Current: {info?.currentVersion ?? 'Checking...'}
+                Current: {currentVersion ?? info?.currentVersion ?? 'Unknown'}
               </div>
               {info?.latestVersion && (
                 <div className="text-sm text-text-muted">
                   Latest: {info.latestVersion}
                 </div>
               )}
-              {info?.isUpdateAvailable && (
-                <div className="text-sm text-accent mt-1">Update available</div>
+              {versionStatus && (
+                <div className={`text-sm mt-1 ${versionStatus.className}`}>{versionStatus.text}</div>
               )}
               {error && (
                 <div className="text-sm text-error mt-1">{error}</div>
@@ -216,12 +249,12 @@ export function GeneralSettings() {
 
             <div className="flex flex-wrap gap-2">
               <button
-                onClick={() => checkForUpdates({ force: true })}
+                onClick={() => checkForUpdates()}
                 disabled={isChecking}
                 className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors disabled:opacity-50"
               >
                 <RefreshCw className={`w-4 h-4 ${isChecking ? 'animate-spin' : ''}`} />
-                {isChecking ? 'Checking...' : 'Check for updates'}
+                Check for updates
               </button>
 
               {info?.isUpdateAvailable && (

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,20 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.11.1',
+    date: '2026-02-06',
+    changes: {
+      changed: [
+        'Update checks are now manual-only from Settings to reduce GitHub API pressure and avoid startup rate-limit noise',
+        'Update attention indicator now appears on Settings instead of a dedicated download icon in the header',
+      ],
+      fixed: [
+        'Updates panel now shows explicit status for all outcomes: up to date, update available, or running newer than latest release',
+        'Current version now displays immediately from local app metadata without requiring a release API call',
+      ],
+    },
+  },
+  {
     version: '0.11.0',
     date: '2026-02-06',
     changes: {

--- a/src/stores/updates.ts
+++ b/src/stores/updates.ts
@@ -2,12 +2,14 @@ import { create } from 'zustand'
 
 interface UpdatesState {
   info: UpdateInfo | null
+  currentVersion: string | null
   isChecking: boolean
   isDownloading: boolean
   downloadProgress: UpdateDownloadProgress | null
   lastChecked: number | null
   lastDownloadedTo: string | null
   error: string | null
+  loadCurrentVersion: () => Promise<string | null>
   checkForUpdates: (options?: { force?: boolean }) => Promise<UpdateInfo | null>
   downloadUpdate: () => Promise<UpdateDownloadResult | null>
   startListening: () => () => void
@@ -15,12 +17,23 @@ interface UpdatesState {
 
 export const useUpdateStore = create<UpdatesState>((set, get) => ({
   info: null,
+  currentVersion: null,
   isChecking: false,
   isDownloading: false,
   downloadProgress: null,
   lastChecked: null,
   lastDownloadedTo: null,
   error: null,
+
+  loadCurrentVersion: async () => {
+    try {
+      const version = await window.jelico.updates.getCurrentVersion()
+      set({ currentVersion: version })
+      return version
+    } catch {
+      return null
+    }
+  },
 
   checkForUpdates: async (options) => {
     const { isChecking, lastChecked, info } = get()
@@ -37,6 +50,7 @@ export const useUpdateStore = create<UpdatesState>((set, get) => ({
       const info = await window.jelico.updates.check()
       set({
         info,
+        currentVersion: info.currentVersion,
         isChecking: false,
         lastChecked: Date.now(),
       })
@@ -45,6 +59,7 @@ export const useUpdateStore = create<UpdatesState>((set, get) => ({
       set({
         isChecking: false,
         error: error instanceof Error ? error.message : 'Update check failed.',
+        lastChecked: Date.now(),
       })
       return null
     }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -60,6 +60,7 @@ interface Window {
       onProgress: (callback: (progress: CompactionProgress) => void) => () => void
     }
     updates: {
+      getCurrentVersion: () => Promise<string>
       check: () => Promise<UpdateInfo>
       download: () => Promise<UpdateDownloadResult>
       openRelease: (url: string) => Promise<boolean>


### PR DESCRIPTION
## Summary
This patch updates the updater flow to be user-initiated and explicit about version state while reducing unnecessary GitHub release API calls.

## What Changed
- Removed startup update checks; updates are now checked from Settings only.
- Added local `currentVersion` IPC so the current app version is shown without calling GitHub.
- Kept updater checks throttled and manual to reduce rate-limit risk.
- Added explicit version status messaging in Settings:
  - `Up to date`
  - `Update available`
  - `Running newer than latest release`
- Moved update attention indicator from the header download icon to Settings:
  - Settings row in sidebar
  - Settings gear badge when sidebar is collapsed
- Updated docs and release metadata:
  - `AGENTS.md`
  - `src/data/changelog.ts`
  - `package.json` and `package-lock.json` to `0.11.1`
  - tag `v0.11.1`

## Validation
- `npx tsc --noEmit`
- `npm run build`
- Manual dev verification of Settings > Updates behavior

## Release Notes (v0.11.1)
- Update checks are now manual-only from Settings to reduce GitHub API pressure and avoid startup rate-limit noise.
- Update attention indicator now appears on Settings instead of a dedicated header download icon.
- Updates panel now shows explicit status for all outcomes: up to date, update available, or running newer than latest release.
- Current version now displays immediately from local app metadata without requiring a release API call.

Fixes #9
