### PR TITLE
v0.11.2: streamline artifact history, sandbox transfer, and artifact testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.11.1
+**Current Version:** 0.11.2
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Jelico will be documented in this file.
 
+## [0.11.2] - 2026-02-07
+
+### Changed
+- Assistant turn history now keeps interleaved text and tool-call blocks after streaming instead of collapsing everything into a separate completed-actions section
+- Sandbox conversation trees now show artifact rows directly with reveal action support and a dedicated **Transfer to Workspace** action at the artifact level
+- Transfer flow now always uses explicit folder selection instead of defaulting to the previously active workspace
+
+### Fixed
+- Stopping generation now marks in-progress tool calls as canceled so tool status cannot remain stuck as running
+- Streamed output no longer leaks inline tool protocol markers such as raw `<|tool_call_*|>` tokens
+- Canvas HTML previews are now interactable in-pane (matching pop-out behavior)
+- Artifact testing is more resilient with title fallback for `open`, better canvas change detection, and clearer `evaluate` error/value reporting
+
 ## [0.8.24] - 2026-02-03
 
 ### Added

--- a/electron/ipc/ai.ts
+++ b/electron/ipc/ai.ts
@@ -1022,7 +1022,9 @@ Actions:
 
 Notes:
 - open with artifact_id always targets latest revision of that artifact's base.
+- Use the session_id returned by open. Do not invent placeholder session IDs.
 - A click should be treated as failed if no observable UI change occurs (unless expect_change=false).
+- For canvas/game interactions, prefer expect_change=false and verify behavior via evaluate/wait_for.
 - These sessions are isolated and hidden from users.`,
     parameters: z.object({
       action: z.enum([

--- a/electron/ipc/conversations.ts
+++ b/electron/ipc/conversations.ts
@@ -21,6 +21,7 @@ function toMessageApi(row: any) {
     conversationId: row.conversation_id,
     role: row.role,
     content: row.content,
+    segments: row.segments,
     toolCalls: row.tool_calls,
     toolResults: row.tool_results,
     attachments: row.attachments,
@@ -58,6 +59,7 @@ export function registerConversationHandlers() {
     const message = messageDb.add(convId, {
       role: messageInput.role,
       content: messageInput.content,
+      segments: messageInput.segments,
       toolCalls: messageInput.toolCalls,
       toolResults: messageInput.toolResults,
       attachments: messageInput.attachments,
@@ -75,6 +77,7 @@ export function registerConversationHandlers() {
   ipcMain.handle('conversations:updateMessage', async (_, messageId: string, updates: any) => {
     const message = messageDb.update(messageId, {
       content: updates.content,
+      segments: updates.segments,
       toolCalls: updates.toolCalls,
       toolResults: updates.toolResults,
       attachments: updates.attachments,

--- a/electron/services/artifactTester.ts
+++ b/electron/services/artifactTester.ts
@@ -101,9 +101,19 @@ async function resolveHtmlFromArtifact(artifactId: string): Promise<{
   artifactTitle: string
   revision: number
 }> {
-  const artifact = artifactDb.get(artifactId)
+  const identifier = artifactId.trim()
+  let artifact = artifactDb.get(identifier)
   if (!artifact) {
-    throw new Error(`Artifact not found: ${artifactId}`)
+    // Some models pass artifact title instead of ID. Accept that as a fallback.
+    const htmlArtifacts = artifactDb.list().filter((row) => row.type === 'html')
+    artifact =
+      htmlArtifacts.find((row) => row.title === identifier) ||
+      htmlArtifacts.find((row) => row.title.toLowerCase() === identifier.toLowerCase()) ||
+      null
+  }
+
+  if (!artifact) {
+    throw new Error(`Artifact not found: ${artifactId}. Provide artifact ID or exact HTML title.`)
   }
 
   const baseId = artifact.base_artifact_id || artifact.id
@@ -263,16 +273,20 @@ export async function artifactTestClick(
     const canvas = document.querySelector('canvas')
     if (!(canvas instanceof HTMLCanvasElement)) return null
     try {
-      const ctx = canvas.getContext('2d')
-      if (!ctx) return null
-      const width = Math.max(1, Math.min(canvas.width || 1, 64))
-      const height = Math.max(1, Math.min(canvas.height || 1, 64))
-      const data = ctx.getImageData(0, 0, width, height).data
+      const sampleSize = 32
+      const sampleCanvas = document.createElement('canvas')
+      sampleCanvas.width = sampleSize
+      sampleCanvas.height = sampleSize
+      const sampleCtx = sampleCanvas.getContext('2d', { willReadFrequently: true })
+      if (!sampleCtx) return null
+      sampleCtx.clearRect(0, 0, sampleSize, sampleSize)
+      sampleCtx.drawImage(canvas, 0, 0, sampleSize, sampleSize)
+      const data = sampleCtx.getImageData(0, 0, sampleSize, sampleSize).data
       let checksum = 0
-      for (let i = 0; i < data.length; i += 16) {
+      for (let i = 0; i < data.length; i += 8) {
         checksum = (checksum + data[i] + data[i + 1] + data[i + 2] + data[i + 3]) % 1000000007
       }
-      return width + 'x' + height + ':' + checksum
+      return sampleSize + 'x' + sampleSize + ':' + checksum
     } catch {
       return null
     }
@@ -397,8 +411,52 @@ export async function artifactTestEvaluate(sessionId: string, expression: string
   if (!session) return { success: false, error: `Session not found: ${sessionId}` }
 
   try {
-    const value = await executeInSession(session, expression)
+    const expressionJson = JSON.stringify(expression)
+    const wrapped = await executeInSession<{
+      success: boolean
+      value?: unknown
+      error?: string
+      stack?: string
+    }>(session, `
+(() => {
+  const expression = ${expressionJson}
+  try {
+    const value = (0, eval)(expression)
     return { success: true, value }
+  } catch (error) {
+    const name = error && typeof error === 'object' && 'name' in error ? String(error.name) : 'Error'
+    const message = error && typeof error === 'object' && 'message' in error ? String(error.message) : String(error)
+    const stack = error && typeof error === 'object' && 'stack' in error
+      ? String(error.stack || '').split('\\n').slice(0, 4).join('\\n')
+      : undefined
+    return { success: false, error: name + ': ' + message, stack }
+  }
+})()
+`)
+
+    if (!wrapped?.success) {
+      return {
+        success: false,
+        error: wrapped?.error || 'Evaluation failed',
+        stack: wrapped?.stack,
+      }
+    }
+
+    const rawValue = wrapped.value
+    const valueType =
+      rawValue === undefined
+        ? 'undefined'
+        : rawValue === null
+          ? 'null'
+          : Array.isArray(rawValue)
+            ? 'array'
+            : typeof rawValue
+
+    return {
+      success: true,
+      value: rawValue === undefined ? null : rawValue,
+      valueType,
+    }
   } catch (error) {
     return { success: false, error: asErrorMessage(error) }
   }

--- a/electron/services/database.ts
+++ b/electron/services/database.ts
@@ -504,6 +504,7 @@ export const messageDb = {
       conversation_id: conversationId,
       role: message.role,
       content: message.content,
+      segments: message.segments,
       tool_calls: message.toolCalls,
       tool_results: message.toolResults,
       attachments: message.attachments,
@@ -526,6 +527,7 @@ export const messageDb = {
     if (!message) return null
 
     if (updates.content !== undefined) message.content = updates.content
+    if (updates.segments !== undefined) message.segments = updates.segments
     if (updates.toolCalls !== undefined) message.tool_calls = updates.toolCalls
     if (updates.toolResults !== undefined) message.tool_results = updates.toolResults
     if (updates.attachments !== undefined) message.attachments = updates.attachments
@@ -596,7 +598,7 @@ interface ToolCallRow {
   id: string
   name: string
   args: Record<string, unknown>
-  status?: 'starting' | 'executing' | 'complete' | 'error'
+  status?: 'starting' | 'executing' | 'complete' | 'error' | 'canceled' | 'cancelled'
 }
 
 interface ToolResultRow {
@@ -604,6 +606,10 @@ interface ToolResultRow {
   result: unknown
   error?: string
 }
+
+type MessageSegmentRow =
+  | { type: 'text'; content: string }
+  | { type: 'tool'; toolCallId: string }
 
 interface MessageAttachment {
   id: string
@@ -626,6 +632,7 @@ interface MessageRow {
   conversation_id: string
   role: string
   content: string
+  segments?: MessageSegmentRow[]
   tool_calls?: ToolCallRow[]
   tool_results?: ToolResultRow[]
   attachments?: MessageAttachment[]
@@ -636,6 +643,7 @@ interface MessageRow {
 interface MessageInput {
   role: string
   content: string
+  segments?: MessageSegmentRow[]
   toolCalls?: ToolCallRow[]
   toolResults?: ToolResultRow[]
   attachments?: MessageAttachment[]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/Canvas/HtmlViewer.tsx
+++ b/src/components/Canvas/HtmlViewer.tsx
@@ -10,6 +10,65 @@ interface HtmlViewerProps {
   onSave?: (content: string) => void
 }
 
+const PREVIEW_STORAGE_SHIM = `<script>
+(() => {
+  const createMemoryStorage = () => {
+    const store = Object.create(null)
+    return {
+      getItem: (key) => (Object.prototype.hasOwnProperty.call(store, key) ? store[String(key)] : null),
+      setItem: (key, value) => { store[String(key)] = String(value) },
+      removeItem: (key) => { delete store[String(key)] },
+      clear: () => {
+        for (const key of Object.keys(store)) {
+          delete store[key]
+        }
+      },
+      key: (index) => Object.keys(store)[index] ?? null,
+      get length() { return Object.keys(store).length },
+    }
+  }
+
+  const ensureStorage = (name) => {
+    try {
+      const existing = window[name]
+      const probe = '__jelico_storage_probe__'
+      existing.setItem(probe, '1')
+      existing.removeItem(probe)
+      return
+    } catch {}
+
+    const fallback = createMemoryStorage()
+    try {
+      Object.defineProperty(window, name, {
+        configurable: true,
+        enumerable: true,
+        value: fallback,
+      })
+      return
+    } catch {}
+
+    try {
+      window[name] = fallback
+    } catch {}
+  }
+
+  ensureStorage('localStorage')
+  ensureStorage('sessionStorage')
+})()
+</script>`
+
+function injectPreviewShim(html: string): string {
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(/<head[^>]*>/i, (match) => `${match}\n${PREVIEW_STORAGE_SHIM}`)
+  }
+
+  if (/<body[^>]*>/i.test(html)) {
+    return html.replace(/<body[^>]*>/i, (match) => `${match}\n${PREVIEW_STORAGE_SHIM}`)
+  }
+
+  return `${PREVIEW_STORAGE_SHIM}\n${html}`
+}
+
 // Debounce hook
 function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value)
@@ -104,13 +163,16 @@ export function HtmlViewer({ html, isStreaming = false, onSave }: HtmlViewerProp
   // Use the HTML as-is if it's a complete document, otherwise wrap it
   // Memoize to avoid recalculating on every render
   const sandboxedHtml = useMemo(() => {
-    if (isCompleteDocument) return displayContent
+    if (isCompleteDocument) {
+      return injectPreviewShim(displayContent)
+    }
 
     return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  ${PREVIEW_STORAGE_SHIM}
   <style>
     * { box-sizing: border-box; }
     body {
@@ -282,7 +344,7 @@ export function HtmlViewer({ html, isStreaming = false, onSave }: HtmlViewerProp
             key={refreshKey}
             srcDoc={sandboxedHtml}
             className="w-full h-full border-0 bg-white"
-            sandbox="allow-scripts allow-forms allow-modals allow-popups"
+            sandbox="allow-scripts allow-forms allow-modals allow-popups allow-pointer-lock"
             title="HTML Preview"
           />
         ) : view === 'diff' ? (

--- a/src/components/Chat/Message.tsx
+++ b/src/components/Chat/Message.tsx
@@ -13,6 +13,7 @@ interface MessageProps {
     role: 'user' | 'assistant' | 'system' | 'tool'
     content: string
     createdAt: number
+    segments?: StreamingSegment[]
     toolCalls?: ToolCall[]
     toolResults?: ToolResult[]
     usage?: MessageUsage
@@ -87,8 +88,8 @@ export function Message({
   // Use streaming tool calls if currently streaming, otherwise use saved tool calls
   const toolCalls = isStreaming ? streamingToolCalls : message.toolCalls
   const toolResults = isStreaming ? streamingToolResults : message.toolResults
-  // Segments are only available during streaming
-  const segments = isStreaming ? streamingSegments : undefined
+  // Prefer live streaming segments while generating, otherwise use persisted segments from message history
+  const segments = isStreaming ? streamingSegments : message.segments
   const normalizedContent = message.content === '(Used tools)' && ((toolCalls?.length || 0) > 0 || (toolResults?.length || 0) > 0)
     ? 'Completed requested tool actions.'
     : message.content

--- a/src/components/Chat/ToolCallDisplay.tsx
+++ b/src/components/Chat/ToolCallDisplay.tsx
@@ -53,12 +53,26 @@ export const HIDDEN_TOOLS = new Set([
   'todo_check',          // Internal status check
 ])
 
+function isCanceledResultPayload(result: unknown): boolean {
+  if (!result || typeof result !== 'object') return false
+  const payload = result as Record<string, unknown>
+  if (payload.canceled === true || payload.cancelled === true) return true
+  const error = String(payload.error || '')
+  return error.toLowerCase().includes('canceled: stream stopped by user')
+}
+
 function formatToolResult(result: unknown): { content: string; isError: boolean } {
   if (typeof result === 'object' && result !== null) {
     const obj = result as Record<string, unknown>
 
     // Handle errors
     if (obj.success === false) {
+      if (isCanceledResultPayload(obj)) {
+        return {
+          content: 'Canceled by user',
+          isError: false,
+        }
+      }
       return {
         content: String(obj.error || 'Unknown error'),
         isError: true
@@ -271,6 +285,7 @@ export function SingleToolCallDisplay({
 
   const hasResult = toolResult !== undefined
   const formattedResult = hasResult ? formatToolResult(toolResult.result) : null
+  const isCanceled = toolCall.status === 'canceled' || toolCall.status === 'cancelled' || isCanceledResultPayload(toolResult?.result)
 
   const formatArtifactType = () => {
     const rawType = String(toolCall.args?.type || '').toLowerCase()
@@ -321,7 +336,10 @@ export function SingleToolCallDisplay({
   }
 
   // Use explicit status if available, otherwise infer from result presence
-  const status = toolCall.status || (hasResult ? 'complete' : (isStreaming ? 'executing' : 'complete'))
+  const inferredStatus = toolCall.status || (hasResult ? 'complete' : (isStreaming ? 'executing' : 'complete'))
+  const status = (!isStreaming && !hasResult && (inferredStatus === 'starting' || inferredStatus === 'executing'))
+    ? 'canceled'
+    : inferredStatus
   const isInProgress = status === 'starting' || status === 'executing'
 
   const isExpandable = (() => {
@@ -383,10 +401,13 @@ export function SingleToolCallDisplay({
             {isInProgress && (
               <Loader2 className="w-4 h-4 text-accent animate-spin flex-shrink-0" />
             )}
-            {hasResult && !formattedResult?.isError && (
+            {isCanceled && (
+              <XCircle className="w-4 h-4 text-text-muted flex-shrink-0" />
+            )}
+            {hasResult && !formattedResult?.isError && !isCanceled && (
               <CheckCircle className="w-4 h-4 text-green-500 flex-shrink-0" />
             )}
-            {(hasResult && formattedResult?.isError) || status === 'error' ? (
+            {!isCanceled && ((hasResult && formattedResult?.isError) || status === 'error') ? (
               <XCircle className="w-4 h-4 text-error flex-shrink-0" />
             ) : null}
           </>
@@ -473,8 +494,6 @@ export function SingleToolCallDisplay({
 }
 
 export function ToolCallDisplay({ toolCalls, toolResults = [], isStreaming }: ToolCallDisplayProps) {
-  const [completedExpanded, setCompletedExpanded] = useState(false)
-
   // Filter out "plumbing" tools that users don't need to see
   const visibleToolCalls = toolCalls.filter(tc => !HIDDEN_TOOLS.has(tc.name))
 
@@ -483,59 +502,16 @@ export function ToolCallDisplay({ toolCalls, toolResults = [], isStreaming }: To
   // Map results by toolCallId for easy lookup
   const resultsMap = new Map(toolResults.map(r => [r.toolCallId, r]))
 
-  // Separate completed vs active tool calls
-  // A tool is complete if it has a result OR its status is 'complete'
-  const completedTools = visibleToolCalls.filter(tc =>
-    resultsMap.has(tc.id) || tc.status === 'complete'
-  )
-  const activeTools = visibleToolCalls.filter(tc =>
-    !resultsMap.has(tc.id) && tc.status !== 'complete'
-  )
-
   return (
     <div className="space-y-2 my-3">
-      {/* Active tool calls - shown normally */}
-      {activeTools.map((toolCall, index) => (
+      {visibleToolCalls.map((toolCall, index) => (
         <SingleToolCallDisplay
-          key={toolCall.id || `active-${index}`}
+          key={toolCall.id || `tool-${index}`}
           toolCall={toolCall}
           toolResult={resultsMap.get(toolCall.id)}
           isStreaming={isStreaming}
         />
       ))}
-
-      {/* Completed actions - collapsible section (shown last) */}
-      {completedTools.length > 0 && (
-        <div className="border border-border rounded-lg overflow-hidden bg-bg-deep">
-          <button
-            onClick={() => setCompletedExpanded(!completedExpanded)}
-            className="w-full flex items-center gap-2 px-3 py-2 hover:bg-bg-hover transition-colors text-left"
-            aria-expanded={completedExpanded}
-            aria-controls="completed-actions-content"
-          >
-            {completedExpanded ? (
-              <ChevronDown className="w-4 h-4 text-text-muted flex-shrink-0" />
-            ) : (
-              <ChevronRight className="w-4 h-4 text-text-muted flex-shrink-0" />
-            )}
-            <CheckCircle className="w-4 h-4 text-green-500 flex-shrink-0" />
-            <span className="text-sm text-text-muted">Completed actions</span>
-          </button>
-
-          {completedExpanded && (
-            <div id="completed-actions-content" className="border-t border-border bg-bg-surface p-2 space-y-2">
-              {completedTools.map((toolCall, index) => (
-                <SingleToolCallDisplay
-                  key={toolCall.id || `completed-${index}`}
-                  toolCall={toolCall}
-                  toolResult={resultsMap.get(toolCall.id)}
-                  isStreaming={false}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/Conversations/TransferDialog.tsx
+++ b/src/components/Conversations/TransferDialog.tsx
@@ -27,11 +27,13 @@ export function TransferDialog({
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
   const [artifactCount, setArtifactCount] = useState(0)
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null)
+  const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace | null>(null)
+  const [isPickingWorkspace, setIsPickingWorkspace] = useState(false)
   const [isTransferring, setIsTransferring] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<{ transferred: number; failed: number } | null>(null)
   const { loadConversations, activeConversationId, setConversationWorkspaceId } = useChatStore()
-  const { setActiveWorkspace } = useWorkspaceStore()
+  const { setActiveWorkspace, loadWorkspaces } = useWorkspaceStore()
 
   // Load workspaces and artifact count
   useEffect(() => {
@@ -49,6 +51,29 @@ export function TransferDialog({
   const currentWorkspace = workspaces.find(w => w.id === currentWorkspaceId)
   const isInSandbox = !currentWorkspaceId
 
+  const handlePickFolder = async () => {
+    setIsPickingWorkspace(true)
+    setError(null)
+
+    try {
+      const workspace = await window.jelico.workspaces.selectFolder()
+      if (!workspace) return
+
+      // Ensure we always transfer to explicitly picked folder, not implicit last selection.
+      setSelectedWorkspaceId(workspace.id)
+      setSelectedWorkspace(workspace)
+
+      // Keep local workspace metadata fresh in case this was a newly created workspace record.
+      const refreshed = await window.jelico.workspaces.list()
+      setWorkspaces(refreshed)
+      await loadWorkspaces()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to pick folder')
+    } finally {
+      setIsPickingWorkspace(false)
+    }
+  }
+
   const handleTransfer = async () => {
     setIsTransferring(true)
     setError(null)
@@ -64,6 +89,7 @@ export function TransferDialog({
 
         // Refresh conversations so the workspace change is reflected in the sidebar
         await loadConversations()
+        await loadWorkspaces()
 
         // Update the local conversation record immediately
         setConversationWorkspaceId(conversationId, nextWorkspaceId)
@@ -90,7 +116,7 @@ export function TransferDialog({
   }
 
   const targetLabel = selectedWorkspaceId
-    ? workspaces.find(w => w.id === selectedWorkspaceId)?.name || 'Unknown'
+    ? selectedWorkspace?.name || workspaces.find(w => w.id === selectedWorkspaceId)?.name || 'Unknown'
     : 'Sandbox'
 
   return (
@@ -146,7 +172,10 @@ export function TransferDialog({
                   {/* Sandbox option */}
                   {!isInSandbox && (
                     <button
-                      onClick={() => setSelectedWorkspaceId(null)}
+                      onClick={() => {
+                        setSelectedWorkspaceId(null)
+                        setSelectedWorkspace(null)
+                      }}
                       className={`w-full flex items-center gap-2 px-3 py-2 text-sm rounded-lg transition-colors text-left ${
                         selectedWorkspaceId === null
                           ? 'bg-accent/10 text-accent border border-accent/30'
@@ -158,30 +187,28 @@ export function TransferDialog({
                     </button>
                   )}
 
-                  {/* Workspace options */}
-                  {workspaces
-                    .filter(w => w.id !== currentWorkspaceId)
-                    .map(workspace => (
-                      <button
-                        key={workspace.id}
-                        onClick={() => setSelectedWorkspaceId(workspace.id)}
-                        className={`w-full flex items-center gap-2 px-3 py-2 text-sm rounded-lg transition-colors text-left ${
-                          selectedWorkspaceId === workspace.id
-                            ? 'bg-accent/10 text-accent border border-accent/30'
-                            : 'text-text-secondary hover:bg-bg-hover border border-transparent'
-                        }`}
-                      >
-                        <FolderOpen className="w-4 h-4" />
-                        <div className="flex-1 min-w-0">
-                          <div className="truncate">{workspace.name}</div>
-                          <div className="text-xs text-text-faint truncate">{workspace.path}</div>
-                        </div>
-                      </button>
-                    ))}
+                  {/* Explicit folder picker - mirrors workspace selector behavior */}
+                  <button
+                    onClick={handlePickFolder}
+                    disabled={isPickingWorkspace || isTransferring}
+                    className={`w-full flex items-center gap-2 px-3 py-2 text-sm rounded-lg transition-colors text-left ${
+                      selectedWorkspaceId
+                        ? 'bg-accent/10 text-accent border border-accent/30'
+                        : 'text-text-secondary hover:bg-bg-hover border border-transparent'
+                    } disabled:opacity-50 disabled:cursor-not-allowed`}
+                  >
+                    <FolderOpen className="w-4 h-4" />
+                    <span>{isPickingWorkspace ? 'Opening folder picker...' : 'Pick folder...'}</span>
+                  </button>
 
-                  {workspaces.length === 0 && isInSandbox && (
-                    <div className="text-sm text-text-muted py-2">
-                      No workspaces available. Create a workspace first.
+                  {selectedWorkspaceId && (
+                    <div className="px-3 py-2 rounded-lg border border-border bg-bg-deep">
+                      <div className="text-sm text-text-primary truncate">
+                        {selectedWorkspace?.name || workspaces.find(w => w.id === selectedWorkspaceId)?.name || 'Selected workspace'}
+                      </div>
+                      <div className="text-xs text-text-faint truncate">
+                        {selectedWorkspace?.path || workspaces.find(w => w.id === selectedWorkspaceId)?.path || ''}
+                      </div>
                     </div>
                   )}
                 </div>
@@ -209,6 +236,7 @@ export function TransferDialog({
               onClick={handleTransfer}
               disabled={
                 isTransferring ||
+                isPickingWorkspace ||
                 (selectedWorkspaceId === null && isInSandbox) ||
                 (selectedWorkspaceId === currentWorkspaceId)
               }

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -3,7 +3,6 @@ import { Plus, Settings, Trash2, FileCode, FileText, Presentation, Image, Chevro
 import { useChatStore } from '../../stores/chat'
 import { useUIStore } from '../../stores/ui'
 import { useArtifactStore, type ArtifactType } from '../../stores/artifacts'
-import { useSandboxStore } from '../../stores/sandbox'
 import { useUpdateStore } from '../../stores/updates'
 import { TransferDialog } from '../Conversations/TransferDialog'
 import { BrailleLoader } from '../StatusIndicators'
@@ -18,46 +17,6 @@ const ARTIFACT_ICONS: Record<ArtifactType, React.ComponentType<{ className?: str
 
 // Fallback icon for unknown artifact types
 const DEFAULT_ARTIFACT_ICON = File
-
-// Get icon for file extension
-function getFileIcon(ext?: string): React.ComponentType<{ className?: string }> {
-  switch (ext) {
-    case 'ts':
-    case 'tsx':
-    case 'js':
-    case 'jsx':
-    case 'py':
-    case 'rb':
-    case 'go':
-    case 'rs':
-    case 'java':
-    case 'c':
-    case 'cpp':
-    case 'h':
-      return FileCode
-    case 'md':
-    case 'txt':
-    case 'json':
-    case 'yaml':
-    case 'yml':
-    case 'toml':
-      return FileText
-    case 'html':
-    case 'htm':
-    case 'css':
-    case 'scss':
-      return Presentation
-    case 'svg':
-    case 'png':
-    case 'jpg':
-    case 'jpeg':
-    case 'gif':
-    case 'webp':
-      return Image
-    default:
-      return File
-  }
-}
 
 // Format date for tooltip
 function formatCreatedDate(timestamp: number): string {
@@ -91,52 +50,11 @@ export function Sidebar() {
   const { conversations, activeConversationId, setActiveConversation, deleteConversation, conversationStreams } = useChatStore()
   const { sidebarCollapsed, openSettings } = useUIStore()
   const { artifacts, selectArtifact, openCanvas } = useArtifactStore()
-  const { loadFiles: loadSandboxFiles } = useSandboxStore()
   const updateAvailable = useUpdateStore((state) => state.info?.isUpdateAvailable)
   // Track which conversations have their artifact trees expanded
   const [expandedConversations, setExpandedConversations] = useState<Set<string>>(new Set())
-  // Track sandbox file counts per conversation (flat list for sidebar display)
-  const [sandboxFileCounts, setSandboxFileCounts] = useState<Record<string, string[]>>({})
   // Transfer dialog state
   const [transferDialogConv, setTransferDialogConv] = useState<{ id: string; title: string; workspaceId: string | null } | null>(null)
-
-  // Load sandbox files for all conversations on mount
-  useEffect(() => {
-    const loadAllSandboxFiles = async () => {
-      const fileCounts: Record<string, string[]> = {}
-      for (const conv of conversations) {
-        try {
-          const convFiles = await window.jelico.sandbox.listFiles(conv.id)
-          if (convFiles.length > 0) {
-            fileCounts[conv.id] = convFiles
-          }
-        } catch {
-          // Ignore errors
-        }
-      }
-      setSandboxFileCounts(fileCounts)
-    }
-    loadAllSandboxFiles()
-  }, [conversations])
-
-  // Reload sandbox files for active conversation when it changes
-  useEffect(() => {
-    if (!activeConversationId) return
-    const refreshSandbox = async () => {
-      try {
-        const files = await window.jelico.sandbox.listFiles(activeConversationId)
-        setSandboxFileCounts(prev => ({
-          ...prev,
-          [activeConversationId]: files,
-        }))
-        // Also load structured data for potential future use
-        loadSandboxFiles(activeConversationId)
-      } catch {
-        // Ignore errors
-      }
-    }
-    refreshSandbox()
-  }, [activeConversationId, loadSandboxFiles])
 
   // Auto-expand artifact tree for active conversation
   useEffect(() => {
@@ -179,7 +97,10 @@ export function Sidebar() {
     }
   }
 
-  const handleOpenTransferDialog = (e: React.MouseEvent, conv: { id: string; title: string; workspaceId?: string | null }) => {
+  const handleOpenTransferDialog = (
+    e: React.MouseEvent,
+    conv: { id: string; title: string; workspaceId?: string | null }
+  ) => {
     e.stopPropagation()
     setTransferDialogConv({
       id: conv.id,
@@ -230,10 +151,8 @@ export function Sidebar() {
             </div>
             {convs.map((conv) => {
               const convArtifacts = getArtifactsForConversation(conv.id)
-              const convSandboxFileList = sandboxFileCounts[conv.id] || []
               const hasArtifacts = convArtifacts.length > 0
-              const hasSandboxFiles = convSandboxFileList.length > 0
-              const hasExpandableContent = hasArtifacts || hasSandboxFiles
+              const hasExpandableContent = hasArtifacts
               const isExpanded = expandedConversations.has(conv.id)
               const isActive = activeConversationId === conv.id
               const isSandboxConversation = !conv.workspaceId
@@ -254,7 +173,7 @@ export function Sidebar() {
                         : 'text-text-secondary hover:text-text-primary hover:bg-bg-hover border-l-2 border-transparent'}
                     `}
                   >
-                    {/* Expand/collapse toggle for artifacts/sandbox */}
+                    {/* Expand/collapse toggle for artifacts */}
                     {hasExpandableContent ? (
                       <button
                         onClick={(e) => toggleConversationArtifacts(e, conv.id)}
@@ -289,7 +208,7 @@ export function Sidebar() {
                     </button>
                   </div>
 
-                  {/* Expandable sub-tree (artifacts with sandbox files indented beneath) */}
+                  {/* Expandable sub-tree (artifacts) */}
                   {hasExpandableContent && isExpanded && (
                     <div className="ml-6 pl-2 border-l border-border/50 mt-1 mb-2">
                       {/* Artifacts section */}
@@ -314,64 +233,32 @@ export function Sidebar() {
                               <Icon className="w-3 h-3 flex-shrink-0" />
                               <span className="truncate">{artifact.title}</span>
                             </button>
-                            {isSandboxConversation ? (
-                              <button
-                                onClick={(e) => handleOpenTransferDialog(e, conv)}
-                                title="Move to workspace..."
-                                className="opacity-0 group-hover:opacity-100 p-1 hover:bg-bg-hover rounded text-text-muted hover:text-accent flex-shrink-0"
-                              >
-                                <FolderUp className="w-3 h-3" />
-                              </button>
-                            ) : (
-                              <button
-                                onClick={async (e) => {
-                                  e.stopPropagation()
-                                  try {
-                                    await window.jelico.artifacts.reveal(artifact.id)
-                                  } catch (error) {
-                                    console.error('Failed to reveal artifact:', error)
-                                  }
-                                }}
-                                title="Reveal in folder"
-                                className="opacity-0 group-hover:opacity-100 p-1 hover:bg-bg-hover rounded text-text-muted hover:text-accent flex-shrink-0"
-                              >
-                                <FolderOpen className="w-3 h-3" />
-                              </button>
-                            )}
+                            <button
+                              onClick={async (e) => {
+                                e.stopPropagation()
+                                try {
+                                  await window.jelico.artifacts.reveal(artifact.id)
+                                } catch (error) {
+                                  console.error('Failed to reveal artifact:', error)
+                                }
+                              }}
+                              title="Reveal in folder"
+                              className="opacity-0 group-hover:opacity-100 p-1 hover:bg-bg-hover rounded text-text-muted hover:text-accent flex-shrink-0"
+                            >
+                              <FolderOpen className="w-3 h-3" />
+                            </button>
                           </div>
                         )
                       })}
 
-                      {/* Sandbox files - indented under artifacts */}
-                      {hasSandboxFiles && (
-                        <div className="ml-3 mt-1">
-                          {convSandboxFileList.slice(0, 10).map((filePath) => {
-                            const fileName = filePath.split('/').pop() || filePath
-                            const ext = fileName.split('.').pop()?.toLowerCase()
-                            const Icon = getFileIcon(ext)
-                            return (
-                              <button
-                                key={filePath}
-                                onClick={async () => {
-                                  setActiveConversation(conv.id)
-                                  // Open sandbox file in a viewer (could integrate with Canvas or external editor)
-                                  const sandboxPath = await window.jelico.sandbox.getConversationPath(conv.id)
-                                  console.log(`Opening sandbox file: ${sandboxPath}/${filePath}`)
-                                }}
-                                className="w-full flex items-center gap-2 px-2 py-1 text-xs text-text-faint hover:text-text-primary hover:bg-bg-hover rounded transition-colors"
-                                title={filePath}
-                              >
-                                <Icon className="w-3 h-3 flex-shrink-0" />
-                                <span className="truncate">{fileName}</span>
-                              </button>
-                            )
-                          })}
-                          {convSandboxFileList.length > 10 && (
-                            <div className="text-[10px] text-text-faint px-2 py-1">
-                              +{convSandboxFileList.length - 10} more files
-                            </div>
-                          )}
-                        </div>
+                      {isSandboxConversation && (
+                        <button
+                          onClick={(e) => handleOpenTransferDialog(e, conv)}
+                          className="mt-2 w-full flex items-center gap-2 py-1.5 text-xs text-accent hover:text-accent hover:bg-bg-hover rounded transition-colors"
+                        >
+                          <FolderUp className="w-3 h-3 flex-shrink-0" />
+                          <span>Transfer to Workspace</span>
+                        </button>
                       )}
                     </div>
                   )}
@@ -404,8 +291,7 @@ export function Sidebar() {
           currentWorkspaceId={transferDialogConv.workspaceId}
           onClose={() => setTransferDialogConv(null)}
           onTransferComplete={() => {
-            // Refresh conversations to get updated workspace assignment
-            // The chat store should handle this automatically via its list method
+            // Chat/workspace state is refreshed by the dialog after transfer
           }}
         />
       )}

--- a/src/components/Workspace/WorkspaceSelector.tsx
+++ b/src/components/Workspace/WorkspaceSelector.tsx
@@ -48,6 +48,15 @@ export function WorkspaceSelector() {
     loadWorkspaces()
   }, [])
 
+  // If we have an active workspace id but no matching metadata, refresh list.
+  useEffect(() => {
+    if (!activeWorkspaceId) return
+    const hasActiveWorkspace = workspaces.some((workspace) => workspace.id === activeWorkspaceId)
+    if (!hasActiveWorkspace) {
+      loadWorkspaces()
+    }
+  }, [activeWorkspaceId, workspaces, loadWorkspaces])
+
   // Load sandbox files when dropdown opens and no workspace is selected
   useEffect(() => {
     if (dropdownOpen && !activeWorkspaceId && activeConversationId) {
@@ -128,6 +137,14 @@ export function WorkspaceSelector() {
                   {activeWorkspace.gitBranch}
                 </span>
               )}
+            </div>
+          </>
+        ) : activeWorkspaceId ? (
+          <>
+            <Folder className="w-4 h-4 text-accent flex-shrink-0" />
+            <div className="flex flex-col items-start leading-tight">
+              <span className="text-text-primary">Workspace</span>
+              <span className="text-xs text-text-muted">Loading...</span>
             </div>
           </>
         ) : (

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,23 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.11.2',
+    date: '2026-02-07',
+    changes: {
+      changed: [
+        'Assistant turns now preserve interleaved text/tool history after streaming instead of collapsing tools under a separate completed-actions bucket',
+        'Sandbox conversation trees now show artifact rows directly with a reveal action and a clear Transfer to Workspace action at the artifact section level',
+        'Transfer dialog now always uses explicit folder picking for workspace transfer targets instead of auto-selecting the last active workspace',
+      ],
+      fixed: [
+        'Stopping a streaming turn now marks in-flight tools as canceled and records canceled results, preventing stale running states in chat history',
+        'Inline tool protocol tokens are now filtered from streamed assistant text to avoid leaking raw tool-call markers into conversation output',
+        'HTML canvas previews now support full interaction in-app via safer storage shims and iframe capability updates',
+        'Artifact test open now accepts HTML artifact titles as a fallback and evaluate now returns clearer execution errors and value typing',
+      ],
+    },
+  },
+  {
     version: '0.11.1',
     date: '2026-02-06',
     changes: {

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -30,6 +30,7 @@ export interface Message {
   conversationId: string
   role: 'user' | 'assistant' | 'system' | 'tool'
   content: string
+  segments?: StreamingSegment[]
   attachments?: MessageAttachment[]
   createdAt: number
   toolCalls?: ToolCall[]
@@ -41,7 +42,7 @@ export interface ToolCall {
   id: string
   name: string
   args: Record<string, unknown>
-  status?: 'starting' | 'executing' | 'complete' | 'error'
+  status?: 'starting' | 'executing' | 'complete' | 'error' | 'canceled' | 'cancelled'
 }
 
 export interface ToolResult {
@@ -181,6 +182,99 @@ interface ChatStore {
 const streamChannelByConversation = new Map<string, string>()
 let modeTransitionTimeoutId: ReturnType<typeof setTimeout> | null = null
 const PENDING_STREAMS_STORAGE_KEY = 'jelico.pending_streams.v1'
+const INLINE_TOOL_CALL_BEGIN_TOKEN = '<|tool_call_begin|>'
+const INLINE_TOOL_CALL_ARGUMENT_BEGIN_TOKEN = '<|tool_call_argument_begin|>'
+const INLINE_TOOL_CALL_END_TOKEN = '<|tool_call_end|>'
+
+function getTrailingTokenOverlap(value: string, token: string): number {
+  const max = Math.min(value.length, token.length - 1)
+  for (let size = max; size > 0; size -= 1) {
+    if (value.endsWith(token.slice(0, size))) {
+      return size
+    }
+  }
+  return 0
+}
+
+function getMaxTrailingTokenOverlap(value: string, tokens: string[]): number {
+  return tokens.reduce((max, token) => Math.max(max, getTrailingTokenOverlap(value, token)), 0)
+}
+
+function createInlineToolProtocolFilter() {
+  const startTokens = [INLINE_TOOL_CALL_BEGIN_TOKEN, INLINE_TOOL_CALL_ARGUMENT_BEGIN_TOKEN]
+  let carry = ''
+  let inProtocol = false
+
+  const consume = (chunk: string): string => {
+    if (!chunk) return ''
+
+    let input = carry + chunk
+    carry = ''
+    let output = ''
+    let cursor = 0
+
+    while (cursor < input.length) {
+      if (inProtocol) {
+        const endIndex = input.indexOf(INLINE_TOOL_CALL_END_TOKEN, cursor)
+        if (endIndex === -1) {
+          const remaining = input.slice(cursor)
+          const overlap = getTrailingTokenOverlap(remaining, INLINE_TOOL_CALL_END_TOKEN)
+          carry = overlap > 0 ? remaining.slice(-overlap) : ''
+          return output
+        }
+
+        cursor = endIndex + INLINE_TOOL_CALL_END_TOKEN.length
+        inProtocol = false
+        continue
+      }
+
+      let nextStartIndex = -1
+      let matchedStartToken = ''
+      for (const token of startTokens) {
+        const idx = input.indexOf(token, cursor)
+        if (idx !== -1 && (nextStartIndex === -1 || idx < nextStartIndex)) {
+          nextStartIndex = idx
+          matchedStartToken = token
+        }
+      }
+
+      if (nextStartIndex === -1) {
+        const remaining = input.slice(cursor)
+        const overlap = getMaxTrailingTokenOverlap(remaining, startTokens)
+        if (overlap > 0) {
+          output += remaining.slice(0, -overlap)
+          carry = remaining.slice(-overlap)
+        } else {
+          output += remaining
+        }
+        return output
+      }
+
+      output += input.slice(cursor, nextStartIndex)
+      cursor = nextStartIndex + matchedStartToken.length
+      inProtocol = true
+    }
+
+    return output
+  }
+
+  const flush = (): string => {
+    if (inProtocol) {
+      inProtocol = false
+      carry = ''
+      return ''
+    }
+
+    const tail = carry
+    carry = ''
+
+    if (!tail) return ''
+    if (tail.includes('<|tool_call')) return ''
+    return tail
+  }
+
+  return { consume, flush }
+}
 
 function readPendingStreamCheckpoints(): Record<string, PendingStreamCheckpoint> {
   try {
@@ -817,39 +911,49 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     const streamStartTime = Date.now()
     let firstChunkTime: number | null = null
     let lastChunkTime: number | null = null
+    const inlineToolProtocolFilter = createInlineToolProtocolFilter()
+
+    const appendStreamTextChunk = (chunk: string) => {
+      fullContent += chunk
+      updateConversationStreamState((current) => {
+        // Find or create the current text segment
+        const segments = [...current.streamingSegments]
+        const lastSegment = segments[segments.length - 1]
+
+        if (lastSegment?.type === 'text') {
+          // Append to existing text segment
+          segments[segments.length - 1] = {
+            type: 'text',
+            content: lastSegment.content + chunk,
+          }
+        } else {
+          // Create new text segment (first text, or text after a tool)
+          segments.push({ type: 'text', content: chunk })
+        }
+
+        return {
+          ...current,
+          streamingContent: fullContent,
+          streamingSegments: segments,
+        }
+      })
+    }
 
     // Handle stream chunks - track text segments for interleaving
     window.jelico.ai.onStreamChunk(channelId, (chunk) => {
       // Guard against undefined chunks (can happen with some stream events)
       if (chunk !== undefined && chunk !== null) {
+        const sanitizedChunk = inlineToolProtocolFilter.consume(chunk)
+        if (!sanitizedChunk) {
+          return
+        }
+
         const now = Date.now()
         if (firstChunkTime === null) {
           firstChunkTime = now
         }
         lastChunkTime = now
-        fullContent += chunk
-        updateConversationStreamState((current) => {
-          // Find or create the current text segment
-          const segments = [...current.streamingSegments]
-          const lastSegment = segments[segments.length - 1]
-
-          if (lastSegment?.type === 'text') {
-            // Append to existing text segment
-            segments[segments.length - 1] = {
-              type: 'text',
-              content: lastSegment.content + chunk,
-            }
-          } else {
-            // Create new text segment (first text, or text after a tool)
-            segments.push({ type: 'text', content: chunk })
-          }
-
-          return {
-            ...current,
-            streamingContent: fullContent,
-            streamingSegments: segments,
-          }
-        })
+        appendStreamTextChunk(sanitizedChunk)
       }
     })
 
@@ -1086,6 +1190,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     // Handle stream end
     window.jelico.ai.onStreamEnd(channelId, async (stats) => {
       window.jelico.ai.removeListeners(channelId)
+      const trailingSanitizedText = inlineToolProtocolFilter.flush()
+      if (trailingSanitizedText) {
+        appendStreamTextChunk(trailingSanitizedText)
+      }
       const activeChannel = streamChannelByConversation.get(targetConversationId)
       if (activeChannel === channelId) {
         streamChannelByConversation.delete(targetConversationId)
@@ -1128,6 +1236,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         const assistantMessage = await window.jelico.conversations.addMessage(targetConversationId, {
           role: 'assistant',
           content: assistantContent,
+          segments: streamSnapshot.streamingSegments.length > 0 ? streamSnapshot.streamingSegments : undefined,
           toolCalls: streamingToolCalls.length > 0 ? streamingToolCalls : undefined,
           toolResults: streamingToolResults.length > 0 ? streamingToolResults : undefined,
           usage,
@@ -1331,14 +1440,41 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     console.log('[Chat Store] Saving partial response:', { hasContent, hasToolCalls })
 
+    // Normalize tool call state on manual stop so UI never shows stale "running" actions.
+    const completedResultIds = new Set(streamingToolResults.map((result) => result.toolCallId))
+    const normalizedToolCalls = streamingToolCalls.map((toolCall) => {
+      if (completedResultIds.has(toolCall.id)) {
+        return toolCall.status === 'complete' ? toolCall : { ...toolCall, status: 'complete' as const }
+      }
+      if (toolCall.status === 'error' || toolCall.status === 'canceled' || toolCall.status === 'cancelled') {
+        return toolCall
+      }
+      return { ...toolCall, status: 'canceled' as const }
+    })
+
+    const interruptedToolResults: ToolResult[] = normalizedToolCalls
+      .filter((toolCall) => !completedResultIds.has(toolCall.id))
+      .map((toolCall) => ({
+        toolCallId: toolCall.id,
+        result: {
+          success: false,
+          canceled: true,
+          error: 'Canceled: stream stopped by user',
+        },
+        error: 'Canceled: stream stopped by user',
+      }))
+
+    const normalizedToolResults = [...streamingToolResults, ...interruptedToolResults]
+
     if (activeConversationId && (hasContent || hasToolCalls)) {
       try {
         // Save the partial response to the database
         const partialMessage = await window.jelico.conversations.addMessage(activeConversationId, {
           role: 'assistant',
           content: hasContent ? streamingContent : '(Stopped)',
-          toolCalls: hasToolCalls ? streamingToolCalls : undefined,
-          toolResults: streamingToolResults.length > 0 ? streamingToolResults : undefined,
+          segments: streamingSegments.length > 0 ? streamingSegments : undefined,
+          toolCalls: hasToolCalls ? normalizedToolCalls : undefined,
+          toolResults: normalizedToolResults.length > 0 ? normalizedToolResults : undefined,
         })
 
         console.log('[Chat Store] Partial message saved:', {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -248,12 +248,17 @@ interface Message {
   conversationId: string
   role: 'user' | 'assistant' | 'system'
   content: string
+  segments?: MessageSegmentData[]
   attachments?: MessageAttachmentData[]
   toolCalls?: ToolCallEvent[]
   toolResults?: ToolResultEvent[]
   usage?: MessageUsageData
   createdAt: number
 }
+
+type MessageSegmentData =
+  | { type: 'text'; content: string }
+  | { type: 'tool'; toolCallId: string }
 
 interface MessageAttachmentData {
   id: string
@@ -266,6 +271,7 @@ interface MessageAttachmentData {
 interface MessageInput {
   role: Message['role']
   content: string
+  segments?: MessageSegmentData[]
   toolCalls?: ToolCallEvent[]
   toolResults?: ToolResultEvent[]
   attachments?: MessageAttachmentData[]
@@ -309,14 +315,14 @@ interface ToolCallEvent {
   id: string
   name: string
   args: Record<string, unknown>
-  status?: 'starting' | 'executing' | 'complete' | 'error'
+  status?: 'starting' | 'executing' | 'complete' | 'error' | 'canceled' | 'cancelled'
 }
 
 interface ToolCallUpdateEvent {
   id: string
   name: string
   args: Record<string, unknown>
-  status: 'starting' | 'executing' | 'complete' | 'error'
+  status: 'starting' | 'executing' | 'complete' | 'error' | 'canceled' | 'cancelled'
 }
 
 interface ToolResultEvent {


### PR DESCRIPTION
## Summary
- persist assistant text/tool segments so post-stream turns keep chronological history
- remove the separate completed-actions bucket and render tool calls inline in message flow
- simplify sandbox sidebar artifact tree to artifact rows only
- add a clear Transfer to Workspace action at the artifact section level
- switch transfer target selection to explicit folder picking instead of defaulting to last active workspace
- improve in-pane HTML preview interaction behavior for canvas-heavy artifacts
- harden artifact testing with title fallback for open, better canvas change detection, and clearer evaluate diagnostics
- mark in-flight tool calls as canceled when users stop a stream
- filter inline tool protocol markers from streamed assistant text

## Validation
- npm run build

## Release Notes
- updated /Users/spencer/.codex/worktrees/7404/jelico/src/data/changelog.ts with 0.11.2 entry
- updated /Users/spencer/.codex/worktrees/7404/jelico/CHANGELOG.md with 0.11.2 notes
- updated /Users/spencer/.codex/worktrees/7404/jelico/AGENTS.md current version to 0.11.2

Fixes #19