### PR TITLE
chore: standardize release notes architecture label to M-series

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,8 @@ jobs:
     needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release == 'true')
+    env:
+      MACOS_ARM_ARCH_LABEL: Apple Silicon (M-series)
     permissions:
       contents: write
 
@@ -147,6 +149,13 @@ jobs:
             echo "version=manual-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
           fi
 
+      - name: Validate release note architecture labels
+        run: |
+          if grep -q "M1/M2/M3" .github/workflows/build.yml; then
+            echo "Deprecated architecture label found. Use 'Apple Silicon (M-series)'." >&2
+            exit 1
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -169,7 +178,7 @@ jobs:
 
             | Platform | Architecture | Download |
             |----------|-------------|----------|
-            | macOS | Apple Silicon (M1/M2/M3) | `.dmg` (arm64) |
+            | macOS | ${{ env.MACOS_ARM_ARCH_LABEL }} | `.dmg` (arm64) |
             | macOS | Intel | `.dmg` (x64) |
             | Windows | 64-bit | `.exe` installer |
             | Linux | 64-bit | `.AppImage`, `.deb`, `.rpm` |


### PR DESCRIPTION
## Summary
- standardize macOS arm architecture label in release notes to `Apple Silicon (M-series)`
- replace hardcoded `M1/M2/M3` text with an environment label in release workflow
- add a validation step that fails if deprecated `M1/M2/M3` text reappears

## Scope
- workflow-only change (`.github/workflows/build.yml`)
- no version bump
- no new release/tag
