### PR TITLE
chore: fix release note architecture guard false positive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,8 @@ jobs:
 
       - name: Validate release note architecture labels
         run: |
-          if grep -q "M1/M2/M3" .github/workflows/build.yml; then
+          release_body=$(sed -n '/^[[:space:]]*body: |$/,$p' .github/workflows/build.yml)
+          if printf "%s\n" "$release_body" | grep -q "M1/M2/M3"; then
             echo "Deprecated architecture label found. Use 'Apple Silicon (M-series)'." >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- fix release-note architecture guard so it checks only the release body block
- avoid false positives caused by self-matching the validation step itself

## Scope
- workflow-only change in `.github/workflows/build.yml`
- no version bump
- no tag
- no release
