### PR TITLE
feat: Add Minimax as native provider option (Issue #51)

### DIFF
--- a/electron/ipc/ai.ts
+++ b/electron/ipc/ai.ts
@@ -414,6 +414,11 @@ function getProviderInstance(providerConfig: any, apiKey: string) {
         apiKey,
         baseURL: 'https://open.bigmodel.cn/api/coding/paas/v4',
       })
+    case 'minimax':
+      return createOpenAI({
+        apiKey,
+        baseURL: 'https://api.minimax.io',
+      })
 
     // Generic compatible providers
     case 'openai-compatible':

--- a/electron/services/subagents.ts
+++ b/electron/services/subagents.ts
@@ -740,6 +740,11 @@ function getProviderClient(providerConfig: any, apiKey: string | null) {
         apiKey: apiKey || '',
         baseURL: 'https://open.bigmodel.cn/api/coding/paas/v4',
       })
+    case 'minimax':
+      return createOpenAI({
+        apiKey: apiKey || '',
+        baseURL: 'https://api.minimax.io',
+      })
 
     // Generic compatible providers
     case 'custom':

--- a/electron/services/webAdapter.ts
+++ b/electron/services/webAdapter.ts
@@ -24,6 +24,7 @@ export function normalizeWebProviderType(rawType: string | null | undefined): We
     case 'anthropic':
       return 'anthropic'
     case 'openai':
+    case 'minimax':
       return 'openai'
     case 'google':
       return 'google'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/Setup/ProviderConfigForm.tsx
+++ b/src/components/Setup/ProviderConfigForm.tsx
@@ -10,6 +10,7 @@ const API_KEY_URLS: Record<string, string> = {
   'zai-china': 'open.bigmodel.cn',
   'zai-coding': 'open.bigmodel.cn',
   'zai-coding-china': 'open.bigmodel.cn',
+  minimax: 'platform.minimax.io',
 }
 
 // Fallback models shown before API key is entered or when fetch fails
@@ -64,6 +65,7 @@ const FALLBACK_MODELS: Record<string, Array<{ id: string; name: string }>> = {
     { id: 'glm-4.5-air', name: 'GLM-4.5 Air' },
     { id: 'glm-4.5-flash', name: 'GLM-4.5 Flash' },
   ],
+  minimax: [],
   // Generic providers - user enters model manually
   'openai-compatible': [],
   'anthropic-compatible': [],
@@ -464,6 +466,7 @@ function getDefaultName(type: string): string {
     'zai-china': 'Z.ai China',
     'zai-coding': 'Z.ai Coding',
     'zai-coding-china': 'Z.ai Coding CN',
+    minimax: 'MiniMax',
     'openai-compatible': 'OpenAI Compatible',
     'anthropic-compatible': 'Anthropic Compatible',
     local: 'Local Server',

--- a/src/components/Setup/ProviderSetup.tsx
+++ b/src/components/Setup/ProviderSetup.tsx
@@ -69,6 +69,13 @@ const PROVIDER_TYPES = [
     defaultModel: 'glm-4.7',
   },
   {
+    type: 'minimax' as const,
+    name: 'MiniMax',
+    description: 'OpenAI Compatible',
+    icon: 'M',
+    defaultModel: 'MiniMax-M1',
+  },
+  {
     type: 'openai-compatible' as const,
     name: 'OpenAI Compatible',
     description: 'Custom Endpoint',

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.23.0',
+    date: '2026-02-22',
+    changes: {
+      added: [
+        'Added Minimax as a native provider option (Issue #51)',
+      ],
+    },
+  },
+  {
     version: '0.22.0',
     date: '2026-02-22',
     changes: {

--- a/src/stores/providers.ts
+++ b/src/stores/providers.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 
 interface ProviderConfig {
   id: string
-  type: 'anthropic' | 'openai' | 'google' | 'ollama' | 'openrouter' | 'custom' | 'local' | 'zai' | 'zai-china' | 'zai-coding' | 'zai-coding-china' | 'openai-compatible' | 'anthropic-compatible'
+  type: 'anthropic' | 'openai' | 'google' | 'ollama' | 'openrouter' | 'custom' | 'local' | 'zai' | 'zai-china' | 'zai-coding' | 'zai-coding-china' | 'minimax' | 'openai-compatible' | 'anthropic-compatible'
   name: string
   baseUrl?: string
   defaultModel: string

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -216,7 +216,7 @@ interface Window {
 
 interface ProviderConfig {
   id: string
-  type: 'anthropic' | 'openai' | 'google' | 'ollama' | 'openrouter' | 'custom' | 'local' | 'zai' | 'zai-china' | 'zai-coding' | 'zai-coding-china' | 'openai-compatible' | 'anthropic-compatible'
+  type: 'anthropic' | 'openai' | 'google' | 'ollama' | 'openrouter' | 'custom' | 'local' | 'zai' | 'zai-china' | 'zai-coding' | 'zai-coding-china' | 'minimax' | 'openai-compatible' | 'anthropic-compatible'
   name: string
   baseUrl?: string
   defaultModel: string


### PR DESCRIPTION
## Summary
Implements Issue #51 - Adds Minimax as a native provider option instead of requiring users to use OpenAI compatible.

## Changes
- Added minimax to provider type definitions
- Implemented Minimax provider in getProviderInstance() with https://api.minimax.io
- Added Minimax to ProviderConfigForm and ProviderSetup UI
- Added web adapter and subagent support

## Testing
- [ ] Configure Minimax provider with API key
- [ ] Send message using Minimax model
- [ ] Verify response streams correctly

## Copilot CLI
Implemented changes. Verified TypeScript compilation.

Created by Kristoff on behalf of Spencer