### PR TITLE
fix: Editor view rendering issues in canvas (Issue #54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.24.0",
+  "version": "0.26.0",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/Canvas/CanvasPanel.tsx
+++ b/src/components/Canvas/CanvasPanel.tsx
@@ -375,8 +375,8 @@ export function CanvasPanel() {
         </div>
       </div>
 
-      {/* Content - with vertical scroll. min-h-0 fixes flexbox height calculation for Monaco */}
-      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+      {/* Content - overflow-hidden prevents scroll issues with Monaco editor. Individual viewers handle their own scrolling. */}
+      <div className="flex-1 min-h-0 overflow-hidden">
         {displayArtifact ? (
           <ArtifactContent artifact={displayArtifact} />
         ) : conversationArtifacts.length === 0 ? (

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.26.0',
+    date: '2026-02-23',
+    changes: {
+      fixed: [
+        'Editor view in canvas now renders correctly without scroll-related artifacts (Fixes #54)',
+      ],
+    },
+  },
+  {
     version: '0.24.0',
     date: '2026-02-22',
     changes: {


### PR DESCRIPTION
## Summary

Fixes #54 - Editor view in canvas now renders correctly without scroll-related artifacts.

## Changes
- Removed overflow-y-auto from CanvasPanel content container
- Changed to overflow-hidden to prevent scroll conflicts with Monaco editor
- Monaco editor now handles its own scrolling properly

## Root Cause
The parent container had overflow-y-auto which created a scrolling ancestor. Monaco editor has known issues when inside scrolling containers, causing progressive render artifacts on scroll.

## Testing
- [ ] Open code artifact in canvas
- [ ] Scroll within editor - verify no rendering issues
- [ ] Verify editor content remains visible and properly formatted

Created by Kristoff on behalf of Spencer