### PR TITLE
feat: Default typography 12px (Issue #58)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.28.0',
+    date: '2026-02-23',
+    changes: {
+      changed: [
+        'Default typography changed from 14px to 12px (Fixes #58)',
+      ],
+    },
+  },
+  {
     version: '0.27.0',
     date: '2026-02-23',
     changes: {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -86,7 +86,7 @@
     background: var(--bg-void);
     color: var(--text-primary);
     line-height: 1.5;
-    font-size: 14px;
+    font-size: 12px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -122,7 +122,7 @@
 
   /* Global application typography scale (outside chat/canvas by container scope) */
   .app-font-scale {
-    font-size: calc(14px * var(--app-font-scale, 1));
+    font-size: calc(12px * var(--app-font-scale, 1));
   }
 
   .app-font-scale .text-xs {


### PR DESCRIPTION
## Summary

Fixes #58 - Changed default typography from 14px to 12px.

## Changes
- body font-size: 14px → 12px
- .app-font-scale font-size: calc(14px * var) → calc(12px * var)
- Affects base typography throughout the app
- Component-specific sizes (.btn, .input) remain at 14px

## Testing
- [ ] Verify text appears smaller throughout the app
- [ ] Check that readability is maintained
- [ ] Verify Tailwind text-sm, text-base scale correctly

Created by Kristoff on behalf of Spencer