### PR TITLE
fix: Text overflow in streaming and tool output (Issue #60)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/Chat/Message.tsx
+++ b/src/components/Chat/Message.tsx
@@ -245,7 +245,7 @@ export function Message({
             )}
             {/* Show text content */}
             {hasContent && (
-              <p className="whitespace-pre-wrap text-sm">{message.content}</p>
+              <p className="whitespace-pre-wrap text-sm break-words">{message.content}</p>
             )}
             {/* Show placeholder if completely empty (shouldn't happen) */}
             {!hasContent && !hasAttachments && (
@@ -350,7 +350,7 @@ export function Message({
           return <MarkdownCodeBlock language={match[1]} codeContent={codeContent} />
         },
         p: ({ children }) => (
-          <p className="mb-3 last:mb-0 text-sm text-text-primary leading-relaxed">
+          <p className="mb-3 last:mb-0 text-sm text-text-primary leading-relaxed [overflow-wrap:anywhere]">
             {children}
           </p>
         ),
@@ -365,14 +365,14 @@ export function Message({
           </ol>
         ),
         li: ({ children }) => (
-          <li className="text-sm text-text-primary">{children}</li>
+          <li className="text-sm text-text-primary [overflow-wrap:anywhere]">{children}</li>
         ),
         a: ({ children, href }) => (
           <a
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-accent hover:underline"
+            className="text-accent hover:underline [overflow-wrap:anywhere]"
           >
             {children}
           </a>

--- a/src/components/Chat/ToolCallDisplay.tsx
+++ b/src/components/Chat/ToolCallDisplay.tsx
@@ -741,7 +741,7 @@ export function SingleToolCallDisplay({
               )}
 
               {progressPreview && (
-                <div className="ml-4 rounded bg-bg-deep px-2.5 py-2 text-xs text-text-secondary whitespace-pre-wrap">
+                <div className="ml-4 rounded bg-bg-deep px-2.5 py-2 text-xs text-text-secondary whitespace-pre-wrap break-words">
                   {progressPreview}
                 </div>
               )}

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.30.0',
+    date: '2026-02-23',
+    changes: {
+      fixed: [
+        'Text overflow in streaming content and tool output now wraps correctly (Fixes #60)',
+      ],
+    },
+  },
+  {
     version: '0.29.0',
     date: '2026-02-23',
     changes: {


### PR DESCRIPTION
## Summary

Fixes #60 - Text in streaming content and tool output no longer overflows horizontally.

## Changes
- Added break-words to progress preview in ToolCallDisplay
- Added break-words to user message content
- Added [overflow-wrap:anywhere] to assistant markdown elements (p, li, a)
- Prevents horizontal overflow for long strings and command output

## Testing
- [ ] Send message with long unbroken string - verify it wraps
- [ ] Trigger tool with long output - verify no horizontal overflow
- [ ] Check streaming content wraps correctly

Created by Kristoff on behalf of Spencer