### PR TITLE
fix: artifact/image preview reliability and mutation validation (Fixes #83)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Jelico is a local-first AI desktop assistant. A native app where you chat with A
 
 The Soul/Memory system should make Jelico increasingly personalized - it learns YOUR coding style, YOUR preferences, YOUR common mistakes. Every conversation teaches it to help YOU better.
 
-**Current Status:** Soul/Memory systems exist but need verification that they're properly injected into AI prompts. Recent stability work also hardened end-of-turn summary finalization to prevent duplicate wrap-up blocks.
+**Current Status:** Soul/Memory systems exist but need verification that they're properly injected into AI prompts. Recent stability work hardened end-of-turn finalization, and artifact/chat image previews now include improved capture reliability plus deterministic mutation-evidence validation.
 
 ## Setup commands
 - Install dependencies: `npm install`
@@ -73,7 +73,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.33.2
+**Current Version:** 0.33.3
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Jelico are documented in this file.
 
+## [0.33.3] - 2026-02-25
+
+### Fixed
+- **Image Attachment Reliability** — Image uploads now preview correctly even when file MIME metadata is incomplete or inconsistent, reducing broken image cards in chat.
+- **Artifact Snapshot Timing** — HTML artifact snapshots now wait for render completion and capture the main visual area, so thumbnails better match what you see in the live preview.
+- **Thumbnail and Lightbox UX** — Artifact preview cards now use a smaller thumbnail, cleaner presentation, and a clear close button when viewing the expanded image.
+- **Artifact Update Visibility** — Updating an existing artifact now also returns preview imagery so create/update workflows stay consistent.
+- **False Completion Claims** — When artifact/file edits are requested, completion text is now gated by actual successful tool evidence, with one silent self-repair attempt before returning an error.
+
 ## [0.33.2] - 2026-02-24
 
 ### Fixed

--- a/electron/ipc/ai.ts
+++ b/electron/ipc/ai.ts
@@ -4,7 +4,7 @@ import { createAnthropic } from '@ai-sdk/anthropic'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { z } from 'zod'
-import { providerDb, conversationDb, messageDb, workspaceDb } from '../services/database'
+import { providerDb, conversationDb, messageDb, workspaceDb, artifactDb } from '../services/database'
 import { keychainService } from '../services/keychain'
 import { getModeSystemPrompt, buildSystemPrompt, type AgentMode, getCachedPrompt } from '../lib/modes'
 import { formatSoulForContext } from '../services/soul'
@@ -235,6 +235,247 @@ function buildDeterministicTurnWrapUp(params: {
   }
 
   return lines.join('\n\n')
+}
+
+const MUTATION_VERB_REGEX = /\b(update|modify|edit|change|fix|improve|revise|rewrite|rework|redraw|recreate|adjust|tweak|add|remove|replace)\b/i
+const CREATION_VERB_REGEX = /\b(create|make|build|generate|scaffold)\b/i
+const ARTIFACT_TARGET_REGEX = /\b(artifact|canvas|html|svg|diagram|mermaid|game|ui|screen|page|component|prototype)\b/i
+const FILE_TARGET_REGEX = /\b(file|files|source|script|module|config|readme|package\.json|tsconfig|json|yaml|yml|toml|md|markdown)\b/i
+const ACTION_REFERENCE_REGEX = /\b(this|that|it|existing|current|same|again|from scratch)\b/i
+const EXPLANATION_ONLY_REGEX = /\b(explain|why|how|what|review|analysis|analy[sz]e|opinion|thoughts)\b/i
+const IMPERATIVE_REQUEST_REGEX = /\b(can you|could you|please|go ahead|i want you to|let's|try to)\b/i
+const ARTIFACT_COMPLETION_CLAIM_REGEX = /\b(created?|built|generated|updated?|modified|revised|redrawn|recreated|rewrote|fixed|changed|completed|done)\b[\s\S]{0,100}\b(artifact|canvas|html|svg|diagram|game|ui|component|page)\b/i
+const FILE_COMPLETION_CLAIM_REGEX = /\b(created?|updated?|edited?|modified|rewrote|wrote|fixed|changed|saved)\b[\s\S]{0,100}\b(file|files|code|script|module|config|readme|json|yaml|toml|ts|tsx|js|jsx|md)\b/i
+const MAX_COMPLETION_VALIDATION_REPAIRS = 1
+
+interface TurnValidationIssue {
+  code:
+    | 'artifact_missing_execution'
+    | 'artifact_execution_failed'
+    | 'file_missing_execution'
+    | 'file_execution_failed'
+    | 'file_write_verification_failed'
+  detail: string
+}
+
+interface TurnValidationResult {
+  valid: boolean
+  issues: TurnValidationIssue[]
+  requiresArtifactEvidence: boolean
+  requiresFileEvidence: boolean
+}
+
+function normalizeMessageContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+
+  return content
+    .map((part) => {
+      if (!part || typeof part !== 'object') return ''
+      const obj = part as Record<string, unknown>
+      if (typeof obj.text === 'string') return obj.text
+      if (typeof obj.content === 'string') return obj.content
+      return ''
+    })
+    .join('\n')
+}
+
+function getLatestUserMessageText(messages: any[]): string {
+  if (!Array.isArray(messages)) return ''
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i]
+    if (!message || message.role !== 'user') continue
+    return normalizeMessageContent(message.content || '')
+  }
+  return ''
+}
+
+function isLikelyActionRequest(text: string): boolean {
+  const trimmed = text.trim()
+  if (!trimmed) return false
+
+  const looksQuestionOnly = trimmed.endsWith('?')
+  if (
+    looksQuestionOnly &&
+    EXPLANATION_ONLY_REGEX.test(trimmed) &&
+    !IMPERATIVE_REQUEST_REGEX.test(trimmed)
+  ) {
+    return false
+  }
+
+  return true
+}
+
+function hasMutationOrCreationVerb(text: string): boolean {
+  return MUTATION_VERB_REGEX.test(text) || CREATION_VERB_REGEX.test(text)
+}
+
+function isLikelyArtifactMutationRequest(text: string, hasExistingArtifacts: boolean): boolean {
+  if (!isLikelyActionRequest(text)) return false
+  if (!hasMutationOrCreationVerb(text)) return false
+  if (ARTIFACT_TARGET_REGEX.test(text)) return true
+  if (hasExistingArtifacts && ACTION_REFERENCE_REGEX.test(text)) return true
+  return false
+}
+
+function isLikelyFileMutationRequest(text: string): boolean {
+  if (!isLikelyActionRequest(text)) return false
+  if (!hasMutationOrCreationVerb(text)) return false
+  if (FILE_TARGET_REGEX.test(text)) return true
+  if (/[./\\][\w.-]+\.[a-z0-9]+/i.test(text)) return true
+  return false
+}
+
+function claimsArtifactMutation(text: string): boolean {
+  return ARTIFACT_COMPLETION_CLAIM_REGEX.test(text)
+}
+
+function claimsFileMutation(text: string): boolean {
+  return FILE_COMPLETION_CLAIM_REGEX.test(text)
+}
+
+function wasExecutionSuccessful(exec: ToolExecution): boolean {
+  if (didToolExecutionFail(exec)) return false
+  return exec.result !== undefined
+}
+
+function resolveValidationRepairDirective(validation: TurnValidationResult): string {
+  const repairLines = [
+    '## Completion Repair (Internal)',
+    'Your previous attempt failed internal completion validation for this same user request.',
+    'Do NOT mention validation, retries, or internal checks to the user.',
+    'Execute the required tool calls now before any completion claims.',
+    'Only state that work is complete after successful tool results are returned.',
+  ]
+
+  if (validation.requiresArtifactEvidence) {
+    repairLines.push('- Artifact work required: use create_artifact or update_artifact for the requested changes.')
+  }
+  if (validation.requiresFileEvidence) {
+    repairLines.push('- File work required: use write_file for the requested file changes.')
+  }
+
+  return repairLines.join('\n')
+}
+
+async function verifyWriteFileExecution(
+  exec: ToolExecution,
+  workspacePath?: string,
+  conversationId?: string
+): Promise<{ ok: boolean; reason?: string; target?: string }> {
+  const pathArg = typeof exec.args.path === 'string' ? exec.args.path : null
+  const contentArg = typeof exec.args.content === 'string' ? exec.args.content : null
+
+  if (!pathArg || contentArg === null) {
+    return { ok: false, reason: 'write_file tool arguments missing path/content.' }
+  }
+
+  const pathModule = await import('path')
+  const fs = await import('fs/promises')
+
+  let resolvedPath: string
+  if (workspacePath) {
+    const normalizedInput = pathArg.replace(/\\/g, '/')
+    const candidatePath = pathModule.isAbsolute(normalizedInput)
+      ? pathModule.resolve(normalizedInput)
+      : pathModule.resolve(workspacePath, normalizedInput)
+    const relativePath = pathModule.relative(workspacePath, candidatePath)
+    const normalizedRelative = relativePath.replace(/\\/g, '/')
+    if (normalizedRelative.startsWith('..') || pathModule.isAbsolute(relativePath)) {
+      return { ok: false, reason: `write_file escaped workspace bounds for path "${pathArg}".` }
+    }
+    resolvedPath = candidatePath
+  } else if (conversationId) {
+    const sandboxDir = getConversationSandboxPath(conversationId)
+    let sanitizedPath = pathArg.replace(/^[a-zA-Z]:/, '')
+    sanitizedPath = sanitizedPath.replace(/^[/\\]+/, '')
+    sanitizedPath = sanitizedPath.replace(/\\/g, '/')
+    const candidatePath = pathModule.resolve(sandboxDir, sanitizedPath)
+    const relativePath = pathModule.relative(sandboxDir, candidatePath)
+    if (relativePath.startsWith('..') || pathModule.isAbsolute(relativePath)) {
+      return { ok: false, reason: `write_file escaped sandbox bounds for path "${pathArg}".` }
+    }
+    resolvedPath = candidatePath
+  } else {
+    const normalizedInput = pathArg.replace(/\\/g, '/')
+    resolvedPath = pathModule.isAbsolute(normalizedInput)
+      ? pathModule.resolve(normalizedInput)
+      : pathModule.resolve(process.cwd(), normalizedInput)
+  }
+
+  let savedContent: string
+  try {
+    savedContent = await fs.readFile(resolvedPath, 'utf-8')
+  } catch (error: any) {
+    return { ok: false, reason: `Unable to read back written file "${resolvedPath}": ${error?.message || error}` }
+  }
+
+  if (savedContent !== contentArg) {
+    return {
+      ok: false,
+      reason: `File content mismatch after write for "${resolvedPath}".`,
+      target: resolvedPath,
+    }
+  }
+
+  return { ok: true, target: resolvedPath }
+}
+
+async function validateTurnMutations(params: {
+  assistantText: string
+  executions: ToolExecution[]
+  workspacePath?: string
+  conversationId?: string
+  expectedArtifactMutation: boolean
+  expectedFileMutation: boolean
+}): Promise<TurnValidationResult> {
+  const issues: TurnValidationIssue[] = []
+  const artifactExecutions = params.executions.filter((exec) => exec.name === 'create_artifact' || exec.name === 'update_artifact')
+  const writeExecutions = params.executions.filter((exec) => exec.name === 'write_file')
+
+  const successfulArtifactExecutions = artifactExecutions.filter(wasExecutionSuccessful)
+  const successfulWriteExecutions = writeExecutions.filter(wasExecutionSuccessful)
+
+  const claimedArtifactMutation = claimsArtifactMutation(params.assistantText)
+  const claimedFileMutation = claimsFileMutation(params.assistantText)
+
+  const requiresArtifactEvidence = params.expectedArtifactMutation || claimedArtifactMutation || artifactExecutions.length > 0
+  const requiresFileEvidence = params.expectedFileMutation || claimedFileMutation || writeExecutions.length > 0
+
+  if (requiresArtifactEvidence && successfulArtifactExecutions.length === 0) {
+    issues.push({
+      code: artifactExecutions.length > 0 ? 'artifact_execution_failed' : 'artifact_missing_execution',
+      detail: artifactExecutions.length > 0
+        ? 'Artifact mutation tool calls ran but did not complete successfully.'
+        : 'Artifact mutation was requested/claimed, but no successful create/update artifact tool call occurred.',
+    })
+  }
+
+  if (requiresFileEvidence && successfulWriteExecutions.length === 0) {
+    issues.push({
+      code: writeExecutions.length > 0 ? 'file_execution_failed' : 'file_missing_execution',
+      detail: writeExecutions.length > 0
+        ? 'File write tool calls ran but did not complete successfully.'
+        : 'File mutation was requested/claimed, but no successful write_file tool call occurred.',
+    })
+  }
+
+  for (const exec of successfulWriteExecutions) {
+    const verification = await verifyWriteFileExecution(exec, params.workspacePath, params.conversationId)
+    if (!verification.ok) {
+      issues.push({
+        code: 'file_write_verification_failed',
+        detail: verification.reason || 'Unable to verify a write_file result by reading the file back.',
+      })
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    requiresArtifactEvidence,
+    requiresFileEvidence,
+  }
 }
 
 /**
@@ -1623,6 +1864,10 @@ For type="html": after creating it, self-test with artifact_test before claiming
       let thumbnailMimeType: string | undefined
       let thumbnailWidth: number | undefined
       let thumbnailHeight: number | undefined
+      let previewBase64: string | undefined
+      let previewMimeType: string | undefined
+      let previewWidth: number | undefined
+      let previewHeight: number | undefined
       let thumbnailError: string | undefined
 
       if (type === 'html') {
@@ -1635,12 +1880,16 @@ For type="html": after creating it, self-test with artifact_test before claiming
           })
           testSessionId = openResult.sessionId
 
-          const screenshotResult = await artifactTestScreenshot(testSessionId, { thumbWidth: 300 })
+          const screenshotResult = await artifactTestScreenshot(testSessionId, { thumbWidth: 300, waitMs: 1500 })
           if (screenshotResult.success && screenshotResult.thumbnailBase64) {
             thumbnailBase64 = screenshotResult.thumbnailBase64
             thumbnailMimeType = screenshotResult.thumbnailMimeType
             thumbnailWidth = screenshotResult.thumbnailWidth
             thumbnailHeight = screenshotResult.thumbnailHeight
+            previewBase64 = screenshotResult.previewBase64
+            previewMimeType = screenshotResult.previewMimeType
+            previewWidth = screenshotResult.previewWidth
+            previewHeight = screenshotResult.previewHeight
           } else {
             thumbnailError = screenshotResult.error || 'Failed to capture HTML thumbnail'
             console.warn('[AI] create_artifact thumbnail capture failed:', thumbnailError)
@@ -1672,6 +1921,10 @@ For type="html": after creating it, self-test with artifact_test before claiming
         thumbnailMimeType,
         thumbnailWidth,
         thumbnailHeight,
+        previewBase64,
+        previewMimeType,
+        previewWidth,
+        previewHeight,
       }
     },
   })
@@ -1723,15 +1976,71 @@ For type="html": after updating it, self-test with artifact_test before claiming
         console.warn('[AI] Artifact update validation warnings:', validation.warnings)
       }
 
+      let thumbnailBase64: string | undefined
+      let thumbnailMimeType: string | undefined
+      let thumbnailWidth: number | undefined
+      let thumbnailHeight: number | undefined
+      let previewBase64: string | undefined
+      let previewMimeType: string | undefined
+      let previewWidth: number | undefined
+      let previewHeight: number | undefined
+      let thumbnailError: string | undefined
+
+      if (type === 'html') {
+        let testSessionId: string | undefined
+        try {
+          const openResult = await openArtifactTestSession({
+            html: content,
+            width: 1200,
+            height: 800,
+          })
+          testSessionId = openResult.sessionId
+
+          const screenshotResult = await artifactTestScreenshot(testSessionId, { thumbWidth: 300, waitMs: 1500 })
+          if (screenshotResult.success && screenshotResult.thumbnailBase64) {
+            thumbnailBase64 = screenshotResult.thumbnailBase64
+            thumbnailMimeType = screenshotResult.thumbnailMimeType
+            thumbnailWidth = screenshotResult.thumbnailWidth
+            thumbnailHeight = screenshotResult.thumbnailHeight
+            previewBase64 = screenshotResult.previewBase64
+            previewMimeType = screenshotResult.previewMimeType
+            previewWidth = screenshotResult.previewWidth
+            previewHeight = screenshotResult.previewHeight
+          } else {
+            thumbnailError = screenshotResult.error || 'Failed to capture HTML thumbnail'
+            console.warn('[AI] update_artifact thumbnail capture failed:', thumbnailError)
+          }
+        } catch (error) {
+          thumbnailError = error instanceof Error ? error.message : String(error)
+          console.warn('[AI] update_artifact thumbnail capture failed:', thumbnailError)
+        } finally {
+          if (testSessionId) {
+            await closeArtifactTestSession(testSessionId)
+          }
+        }
+      }
+
       if (sendUpdateArtifact) {
         sendUpdateArtifact({ id, updates: { title, content, language } })
+      }
+      const combinedWarnings = [...validation.warnings]
+      if (thumbnailError) {
+        combinedWarnings.push(`Thumbnail capture failed: ${thumbnailError}`)
       }
       return {
         success: true,
         message: type === 'html'
           ? `Artifact "${id}" updated successfully. Next step required: run artifact_test and verify behavior before claiming success.`
           : `Artifact "${id}" updated successfully`,
-        warnings: validation.warnings.length > 0 ? validation.warnings : undefined,
+        warnings: combinedWarnings.length > 0 ? combinedWarnings : undefined,
+        thumbnailBase64,
+        thumbnailMimeType,
+        thumbnailWidth,
+        thumbnailHeight,
+        previewBase64,
+        previewMimeType,
+        previewWidth,
+        previewHeight,
       }
     },
   })
@@ -2956,6 +3265,16 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
           }
         })
 
+      const latestUserText = getLatestUserMessageText(params.messages)
+      const existingArtifactCount = Array.isArray(params.artifacts) && params.artifacts.length > 0
+        ? params.artifacts.length
+        : (params.conversationId ? artifactDb.getByConversation(params.conversationId).length : 0)
+      const hasExistingArtifacts = existingArtifactCount > 0
+      const expectedArtifactMutation = isLikelyArtifactMutationRequest(latestUserText, hasExistingArtifacts)
+      const expectedFileMutation = isLikelyFileMutationRequest(latestUserText)
+      let completionValidationRepairAttempts = 0
+      let pendingCompletionRepairDirective = ''
+
       // Retry loop for transient errors
       let lastError: any = null
       const streamMaxTokens = await resolveProviderMaxOutputTokens(providerConfig, modelId)
@@ -2976,6 +3295,14 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
           await sleep(RETRY_DELAY_MS * attempt) // Exponential backoff
         }
 
+        const attemptSystemPrompt = pendingCompletionRepairDirective
+          ? `${systemPrompt}\n\n${pendingCompletionRepairDirective}`
+          : systemPrompt
+        const shouldBufferCompletionSensitiveText =
+          expectedArtifactMutation ||
+          expectedFileMutation ||
+          !!pendingCompletionRepairDirective
+
         // Track step count for warning injection
         let stepCount = 0
         const MAX_TOOL_STEPS = 50
@@ -2986,7 +3313,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
           const chatModel = provider.chat(modelId)
           const result = await streamText({
             model: chatModel,
-            system: systemPrompt,
+            system: attemptSystemPrompt,
             messages,
             tools,
             toolChoice: 'auto',
@@ -3021,9 +3348,20 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
           // Track text generated after the last meaningful (user-visible) action.
           // Internal plumbing tools should not reset this.
           let textAfterLastMeaningfulAction = ''
-          let totalStreamedTextLength = 0  // Track total text sent to prevent duplicate sending
+          let totalStreamedTextLength = 0  // Track total text generated to prevent duplicate fallback text
           let streamedTextTail = '' // Track tail for spacing decisions
           let hadMeaningfulToolActivity = false
+          let assistantTextForValidation = ''
+          const bufferedAssistantChunks: string[] = []
+          const emitAssistantChunk = (chunk: string) => {
+            if (!chunk) return
+            assistantTextForValidation += chunk
+            if (shouldBufferCompletionSensitiveText) {
+              bufferedAssistantChunks.push(chunk)
+              return
+            }
+            event.sender.send(`ai:chunk:${channelId}`, chunk)
+          }
 
           // Track current tool receiving input (for progress display AND accumulation)
           let currentToolInputId: string | null = null
@@ -3060,7 +3398,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
                   thinkState = newThinkState
                   
                   if (cleanedChunk) {
-                    event.sender.send(`ai:chunk:${channelId}`, cleanedChunk)
+                    emitAssistantChunk(cleanedChunk)
                     textAfterLastMeaningfulAction += cleanedChunk
                     totalStreamedTextLength += cleanedChunk.length  // Track total to prevent duplicate sending
                     streamedTextTail = (streamedTextTail + cleanedChunk).slice(-4)
@@ -3446,7 +3784,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
           const finalText = await result.text
           // Only send if NO text was streamed at all (prevents duplicate sending on timeout)
           if (finalText && totalStreamedTextLength === 0) {
-            event.sender.send(`ai:chunk:${channelId}`, finalText)
+            emitAssistantChunk(finalText)
             textAfterLastMeaningfulAction = finalText
             totalStreamedTextLength += finalText.length
             streamedTextTail = (streamedTextTail + finalText).slice(-4)
@@ -3623,7 +3961,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
               }
             }
 
-            event.sender.send(`ai:chunk:${channelId}`, wrapUpText)
+            emitAssistantChunk(wrapUpText)
             totalStreamedTextLength += wrapUpText.length
             streamedTextTail = (streamedTextTail + wrapUpText).slice(-4)
             textAfterLastMeaningfulAction += wrapUpText
@@ -3636,9 +3974,43 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
             const fallbackText = usedToolsOrAgents
               ? 'Completed requested tool actions.'
               : 'No response text was returned. Please retry.'
-            event.sender.send(`ai:chunk:${channelId}`, fallbackText)
+            emitAssistantChunk(fallbackText)
             totalStreamedTextLength += fallbackText.length
             streamedTextTail = (streamedTextTail + fallbackText).slice(-4)
+          }
+
+          if (!abortController.signal.aborted) {
+            const turnValidation = await validateTurnMutations({
+              assistantText: assistantTextForValidation,
+              executions: Array.from(toolTracker.values()),
+              workspacePath: params.workspacePath,
+              conversationId: params.conversationId,
+              expectedArtifactMutation,
+              expectedFileMutation,
+            })
+
+            if (!turnValidation.valid) {
+              if (DEBUG_API_REQUESTS) {
+                console.warn('[AI] Completion validation failed:', turnValidation.issues)
+              }
+
+              if (
+                completionValidationRepairAttempts < MAX_COMPLETION_VALIDATION_REPAIRS &&
+                attempt < MAX_RETRIES
+              ) {
+                completionValidationRepairAttempts += 1
+                pendingCompletionRepairDirective = resolveValidationRepairDirective(turnValidation)
+                continue
+              }
+
+              throw new Error('I could not verify that the requested artifact/file updates were applied. Please retry.')
+            }
+          }
+
+          pendingCompletionRepairDirective = ''
+
+          if (!abortController.signal.aborted && shouldBufferCompletionSensitiveText && bufferedAssistantChunks.length > 0) {
+            event.sender.send(`ai:chunk:${channelId}`, bufferedAssistantChunks.join(''))
           }
 
           const totalTokens = promptTokens + completionTokens
@@ -3904,3 +4276,4 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
     return { success: true }
   })
 }
+

--- a/electron/services/artifactTester.ts
+++ b/electron/services/artifactTester.ts
@@ -540,13 +540,104 @@ export async function artifactTestWaitFor(input: {
 
 interface ArtifactTestScreenshotOptions {
   thumbWidth?: number
+  waitMs?: number
+}
+
+interface CaptureRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+async function getPreferredCaptureRect(session: ArtifactTestSession): Promise<CaptureRect | null> {
+  try {
+    const rect = await executeInSession<CaptureRect | null>(session, `
+(() => {
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0
+  if (!viewportWidth || !viewportHeight) return null
+
+  const minArea = Math.max(120 * 120, Math.floor(viewportWidth * viewportHeight * 0.08))
+
+  const toNumber = (value) => {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+
+  const isVisible = (el) => {
+    const style = window.getComputedStyle(el)
+    if (style.display === 'none' || style.visibility === 'hidden') return false
+    if (toNumber(style.opacity) === 0) return false
+    return true
+  }
+
+  const clampRect = (rect) => {
+    const left = Math.max(0, Math.floor(rect.left))
+    const top = Math.max(0, Math.floor(rect.top))
+    const right = Math.min(viewportWidth, Math.ceil(rect.right))
+    const bottom = Math.min(viewportHeight, Math.ceil(rect.bottom))
+    const width = right - left
+    const height = bottom - top
+    if (width < 80 || height < 80) return null
+    return { x: left, y: top, width, height }
+  }
+
+  const canvases = Array.from(document.querySelectorAll('canvas'))
+  let best = null
+
+  for (const canvas of canvases) {
+    if (!(canvas instanceof Element)) continue
+    if (!isVisible(canvas)) continue
+
+    const clamped = clampRect(canvas.getBoundingClientRect())
+    if (!clamped) continue
+
+    const area = clamped.width * clamped.height
+    if (area < minArea) continue
+
+    if (!best || area > best.area) {
+      best = { ...clamped, area }
+    }
+  }
+
+  if (!best) return null
+
+  const pad = 12
+  const x = Math.max(0, best.x - pad)
+  const y = Math.max(0, best.y - pad)
+  const right = Math.min(viewportWidth, best.x + best.width + pad)
+  const bottom = Math.min(viewportHeight, best.y + best.height + pad)
+
+  const width = Math.max(1, right - x)
+  const height = Math.max(1, bottom - y)
+  return { x, y, width, height }
+})()
+`)
+
+    if (!rect) return null
+    if (rect.width <= 0 || rect.height <= 0) return null
+    return rect
+  } catch {
+    return null
+  }
 }
 
 export async function artifactTestScreenshot(sessionId: string, options: ArtifactTestScreenshotOptions = {}) {
   const session = getSession(sessionId)
   if (!session) return { success: false, error: `Session not found: ${sessionId}` }
 
-  const image = await session.win.webContents.capturePage()
+  // Let the page settle before capture so dynamic UIs are fully painted.
+  const requestedWaitMs = Math.round(options.waitMs ?? 1200)
+  const waitMs = Math.max(0, Math.min(5000, Number.isFinite(requestedWaitMs) ? requestedWaitMs : 1200))
+  if (waitMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, waitMs))
+  }
+
+  const preferredRect = await getPreferredCaptureRect(session)
+  const image = preferredRect
+    ? await session.win.webContents.capturePage(preferredRect)
+    : await session.win.webContents.capturePage()
   const png = image.toPNG()
   const outputPath = path.join(app.getPath('temp'), `jelico-artifact-test-${sessionId}-${Date.now()}.png`)
   await fs.writeFile(outputPath, png)
@@ -563,6 +654,10 @@ export async function artifactTestScreenshot(sessionId: string, options: Artifac
     path: outputPath,
     width: size.width,
     height: size.height,
+    previewBase64: png.toString('base64'),
+    previewMimeType: 'image/png',
+    previewWidth: size.width,
+    previewHeight: size.height,
     thumbnailBase64: thumbnailJpeg,
     thumbnailMimeType: 'image/jpeg',
     thumbnailWidth: thumbnailSize.width,

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; frame-src 'self' blob: data:; media-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net https://huggingface.co https://*.huggingface.co; worker-src 'self' blob:">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; frame-src 'self' blob: data:; media-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net https://huggingface.co https://*.huggingface.co; worker-src 'self' blob:">
     <title>Jelico</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.33.2",
+  "version": "0.33.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.33.2",
+      "version": "0.33.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.33.2",
+  "version": "0.33.3",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -31,7 +31,22 @@ const SUPPORTED_FILE_TYPES = {
   document: ['application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
 }
 
-const ACCEPTED_EXTENSIONS = '.png,.jpg,.jpeg,.gif,.webp,.txt,.md,.json,.pdf,.docx,.pptx'
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  svg: 'image/svg+xml',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+  avif: 'image/avif',
+  heic: 'image/heic',
+  heif: 'image/heif',
+}
+
+const ACCEPTED_EXTENSIONS = '.png,.jpg,.jpeg,.gif,.webp,.bmp,.svg,.tif,.tiff,.avif,.heic,.heif,.txt,.md,.json,.pdf,.docx,.pptx'
 
 // Line threshold for collapsing pasted content
 const PASTE_COLLAPSE_THRESHOLD = 10
@@ -40,6 +55,28 @@ const chatDraftsByConversation = new Map<string, string>()
 
 function getDraftKey(conversationId: string | null): string {
   return conversationId || NEW_CHAT_DRAFT_KEY
+}
+
+function getFileExtension(fileName: string): string {
+  const lastDot = fileName.lastIndexOf('.')
+  if (lastDot === -1 || lastDot === fileName.length - 1) return ''
+  return fileName.slice(lastDot + 1).toLowerCase()
+}
+
+function inferMimeTypeFromFilename(fileName: string): string | null {
+  const extension = getFileExtension(fileName)
+  return IMAGE_MIME_BY_EXTENSION[extension] || null
+}
+
+function normalizeFileMimeType(file: File): string {
+  const raw = file.type.trim().toLowerCase()
+  if (raw && raw !== 'application/octet-stream') return raw
+
+  const inferredFromName = inferMimeTypeFromFilename(file.name)
+  if (inferredFromName) return inferredFromName
+
+  if (raw) return raw
+  return 'application/octet-stream'
 }
 
 interface ChatInputProps {
@@ -126,8 +163,11 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
   const getFileIcon = (file: File | undefined, type: string) => {
     if (type === 'pasted') return FileText
     if (!file) return File
-    if (SUPPORTED_FILE_TYPES.image.includes(file.type)) return Image
-    if (SUPPORTED_FILE_TYPES.text.includes(file.type)) return FileText
+
+    const normalizedMimeType = normalizeFileMimeType(file)
+    if (normalizedMimeType.startsWith('image/')) return Image
+    if (SUPPORTED_FILE_TYPES.text.includes(normalizedMimeType) || normalizedMimeType.startsWith('text/')) return FileText
+
     return File
   }
 
@@ -271,8 +311,8 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
 
   // Determine attachment type from MIME type
   const getAttachmentType = (mimeType: string): 'image' | 'text' | 'document' => {
-    if (SUPPORTED_FILE_TYPES.image.includes(mimeType)) return 'image'
-    if (SUPPORTED_FILE_TYPES.text.includes(mimeType)) return 'text'
+    if (mimeType.startsWith('image/')) return 'image'
+    if (SUPPORTED_FILE_TYPES.text.includes(mimeType) || mimeType.startsWith('text/')) return 'text'
     return 'document'
   }
 
@@ -292,12 +332,13 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
             data: att.content || '',
           }
         } else if (att.file) {
+          const normalizedMimeType = normalizeFileMimeType(att.file)
           const base64 = await fileToBase64(att.file)
           return {
             id: att.id,
-            type: getAttachmentType(att.file.type),
+            type: getAttachmentType(normalizedMimeType),
             name: att.name,
-            mimeType: att.file.type,
+            mimeType: normalizedMimeType,
             data: base64,
           }
         }

--- a/src/components/Chat/Message.tsx
+++ b/src/components/Chat/Message.tsx
@@ -33,6 +33,84 @@ interface MessageProps {
   userName?: string  // User's name for avatar initial
 }
 
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  svg: 'image/svg+xml',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+  avif: 'image/avif',
+  heic: 'image/heic',
+  heif: 'image/heif',
+}
+
+function getFileExtension(fileName: string): string {
+  const lastDot = fileName.lastIndexOf('.')
+  if (lastDot === -1 || lastDot === fileName.length - 1) return ''
+  return fileName.slice(lastDot + 1).toLowerCase()
+}
+
+function inferImageMimeTypeFromName(fileName: string): string | null {
+  const extension = getFileExtension(fileName)
+  return IMAGE_MIME_BY_EXTENSION[extension] || null
+}
+
+function inferImageMimeTypeFromBase64(base64Data: string): string | null {
+  const sample = base64Data.slice(0, 32)
+  if (sample.startsWith('iVBORw0KGgo')) return 'image/png'
+  if (sample.startsWith('/9j/')) return 'image/jpeg'
+  if (sample.startsWith('R0lGOD')) return 'image/gif'
+  if (sample.startsWith('UklGR')) return 'image/webp'
+  if (sample.startsWith('Qk')) return 'image/bmp'
+  if (sample.startsWith('PHN2Zy') || sample.startsWith('PD94bWwg')) return 'image/svg+xml'
+  return null
+}
+
+function normalizeImageMimeType(mimeType: string, fileName: string, base64Data: string): string {
+  const normalizedMime = mimeType.trim().toLowerCase()
+  if (normalizedMime.startsWith('image/')) return normalizedMime
+
+  const inferredFromName = inferImageMimeTypeFromName(fileName)
+  if (inferredFromName) return inferredFromName
+
+  const inferredFromData = inferImageMimeTypeFromBase64(base64Data)
+  if (inferredFromData) return inferredFromData
+
+  return 'image/png'
+}
+
+function isDataUrl(value: string): boolean {
+  return value.trim().toLowerCase().startsWith('data:')
+}
+
+function resolveAttachmentImageSource(att: MessageAttachment): string | null {
+  const rawData = att.data?.trim()
+  if (!rawData) return null
+
+  if (isDataUrl(rawData)) {
+    return rawData
+  }
+
+  if (
+    rawData.startsWith('http://') ||
+    rawData.startsWith('https://') ||
+    rawData.startsWith('blob:') ||
+    rawData.startsWith('file:')
+  ) {
+    return rawData
+  }
+
+  const compactBase64 = rawData.replace(/\s+/g, '')
+  if (!compactBase64) return null
+
+  const mimeType = normalizeImageMimeType(att.mimeType || '', att.name || '', compactBase64)
+  return `data:${mimeType};base64,${compactBase64}`
+}
+
 // User avatar - shows first initial or fallback icon
 function UserAvatar({ name }: { name?: string }) {
   const initial = name?.trim().charAt(0).toUpperCase()
@@ -140,6 +218,7 @@ export function Message({
 }: MessageProps) {
   const [copied, setCopied] = useState(false)
   const [lightboxImageUrl, setLightboxImageUrl] = useState<string | null>(null)
+  const [failedImagePreviews, setFailedImagePreviews] = useState<Record<string, boolean>>({})
   const isUser = message.role === 'user'
   const isAssistant = message.role === 'assistant'
   const timestamp = formatTimestamp(message.createdAt)
@@ -178,6 +257,16 @@ export function Message({
     setLightboxImageUrl(null)
   }
 
+  const markImagePreviewFailed = (key: string) => {
+    setFailedImagePreviews((prev) => (
+      prev[key]
+        ? prev
+        : { ...prev, [key]: true }
+    ))
+  }
+
+  const canOpenLightboxInNewTab = lightboxImageUrl ? !isDataUrl(lightboxImageUrl) : false
+
   // Get icon for attachment type
   const getAttachmentIcon = (type: string) => {
     switch (type) {
@@ -207,10 +296,11 @@ export function Message({
                 {message.attachments!.map((att) => {
                   const IconComponent = getAttachmentIcon(att.type)
                   const isTextAttachment = att.type === 'text' && att.data
-
+                  const imagePreviewKey = `att:${att.id}`
                   const imageSrc = att.type === 'image'
-                    ? `data:${att.mimeType};base64,${att.data}`
+                    ? resolveAttachmentImageSource(att)
                     : null
+                  const imagePreviewFailed = Boolean(failedImagePreviews[imagePreviewKey])
 
                   return (
                     <div key={att.id} className="text-sm">
@@ -218,7 +308,7 @@ export function Message({
                         <IconComponent className="w-4 h-4" />
                         <span>{att.name}</span>
                       </div>
-                      {imageSrc && (
+                      {imageSrc && !imagePreviewFailed && (
                         <button
                           type="button"
                           onClick={() => openLightbox(imageSrc)}
@@ -229,8 +319,14 @@ export function Message({
                             src={imageSrc}
                             alt={att.name}
                             className="max-h-40 max-w-full object-cover"
+                            onError={() => markImagePreviewFailed(imagePreviewKey)}
                           />
                         </button>
+                      )}
+                      {att.type === 'image' && (!imageSrc || imagePreviewFailed) && (
+                        <div className="rounded-lg border border-border bg-bg-deep px-3 py-2 text-xs text-text-muted">
+                          Preview unavailable for this image attachment.
+                        </div>
                       )}
                       {/* Show text content for pasted text */}
                       {isTextAttachment && (
@@ -303,16 +399,18 @@ export function Message({
               <img
                 src={lightboxImageUrl}
                 alt="Full-size preview"
-                className="max-w-[70vw] max-h-[70vh] object-contain rounded-lg"
+                className="max-w-[80vw] max-h-[80vh] object-contain rounded-lg"
               />
-              <a
-                href={lightboxImageUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-accent hover:underline break-all"
-              >
-                {lightboxImageUrl}
-              </a>
+              {canOpenLightboxInNewTab && (
+                <a
+                  href={lightboxImageUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-accent hover:underline"
+                >
+                  Open image in new tab
+                </a>
+              )}
             </div>
           </div>
         )}
@@ -379,6 +477,14 @@ export function Message({
         ),
         img: ({ src, alt }) => {
           if (!src) return null
+          const imagePreviewKey = `md:${src}`
+          if (failedImagePreviews[imagePreviewKey]) {
+            return (
+              <div className="my-3 rounded-lg border border-border bg-bg-deep px-3 py-2 text-xs text-text-muted">
+                Image preview unavailable.
+              </div>
+            )
+          }
           return (
             <button
               type="button"
@@ -390,6 +496,7 @@ export function Message({
                 src={src}
                 alt={alt || 'Image'}
                 className="max-h-48 max-w-full object-contain"
+                onError={() => markImagePreviewFailed(imagePreviewKey)}
               />
             </button>
           )
@@ -500,16 +607,18 @@ export function Message({
             <img
               src={lightboxImageUrl}
               alt="Full-size preview"
-              className="max-w-[70vw] max-h-[70vh] object-contain rounded-lg"
+              className="max-w-[80vw] max-h-[80vh] object-contain rounded-lg"
             />
-            <a
-              href={lightboxImageUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-accent hover:underline break-all"
-            >
-              {lightboxImageUrl}
-            </a>
+            {canOpenLightboxInNewTab && (
+              <a
+                href={lightboxImageUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-accent hover:underline"
+              >
+                Open image in new tab
+              </a>
+            )}
           </div>
         </div>
       )}

--- a/src/components/Chat/ToolCallDisplay.tsx
+++ b/src/components/Chat/ToolCallDisplay.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   ChevronDown,
   ChevronRight,
   CheckCircle,
   XCircle,
-  ExternalLink
+  ExternalLink,
+  X,
 } from 'lucide-react'
 import { DiffViewer } from '../Canvas/DiffViewer'
 import type { ToolCall, ToolResult } from '../../stores/chat'
@@ -55,6 +56,84 @@ export const HIDDEN_TOOLS = new Set([
 ])
 
 const INTERNAL_WEB_GATE_RESULT_TYPES = new Set(['deferred_to_subagents', 'direct_limit_reached'])
+
+function isPreviewUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+  return (
+    normalized.startsWith('data:') ||
+    normalized.startsWith('http://') ||
+    normalized.startsWith('https://') ||
+    normalized.startsWith('blob:') ||
+    normalized.startsWith('file:')
+  )
+}
+
+function resolveArtifactImageSource(
+  result: Record<string, unknown> | null,
+  options: {
+    dataUrlKey: string
+    base64Key: string
+    mimeKey: string
+    defaultMimeType: string
+  }
+): string | null {
+  if (!result) return null
+
+  const explicitDataUrl = typeof result[options.dataUrlKey] === 'string'
+    ? String(result[options.dataUrlKey]).trim()
+    : ''
+  if (explicitDataUrl && isPreviewUrl(explicitDataUrl)) {
+    return explicitDataUrl
+  }
+
+  const rawPayload = typeof result[options.base64Key] === 'string'
+    ? String(result[options.base64Key]).trim()
+    : ''
+  if (!rawPayload) return null
+
+  if (isPreviewUrl(rawPayload)) {
+    return rawPayload
+  }
+
+  const compactBase64 = rawPayload.replace(/\s+/g, '')
+  if (!compactBase64) return null
+
+  let mimeType = typeof result[options.mimeKey] === 'string'
+    ? String(result[options.mimeKey]).trim().toLowerCase()
+    : options.defaultMimeType
+
+  if (mimeType.startsWith('data:')) {
+    if (mimeType.includes(',')) {
+      return mimeType
+    }
+    return `${mimeType},${compactBase64}`
+  }
+
+  mimeType = mimeType.replace(/;base64$/i, '').replace(/;$/, '')
+  if (!mimeType.includes('/')) {
+    mimeType = options.defaultMimeType
+  }
+
+  return `data:${mimeType};base64,${compactBase64}`
+}
+
+function resolveArtifactThumbnailSource(result: Record<string, unknown> | null): string | null {
+  return resolveArtifactImageSource(result, {
+    dataUrlKey: 'thumbnailDataUrl',
+    base64Key: 'thumbnailBase64',
+    mimeKey: 'thumbnailMimeType',
+    defaultMimeType: 'image/jpeg',
+  })
+}
+
+function resolveArtifactPreviewSource(result: Record<string, unknown> | null): string | null {
+  return resolveArtifactImageSource(result, {
+    dataUrlKey: 'previewDataUrl',
+    base64Key: 'previewBase64',
+    mimeKey: 'previewMimeType',
+    defaultMimeType: 'image/png',
+  })
+}
 
 function isInternalWebGateResultPayload(result: unknown): boolean {
   if (!result || typeof result !== 'object') return false
@@ -412,6 +491,8 @@ export function SingleToolCallDisplay({
 }) {
   const [expanded, setExpanded] = useState(false)
   const [isThumbnailOpen, setIsThumbnailOpen] = useState(false)
+  const [isThumbnailFailed, setIsThumbnailFailed] = useState(false)
+  const [isPreviewFailed, setIsPreviewFailed] = useState(false)
 
   const { agents } = useAgentStore()
   const activeConversationId = useChatStore((state) => state.activeConversationId)
@@ -574,53 +655,97 @@ export function SingleToolCallDisplay({
     ? `tool-call-pill-processing tool-call-pill-processing-tone-${(processingTone ?? 0) % 4}`
     : ''
 
+  const isCreateArtifactTool = toolCall.name === 'create_artifact'
+  const isUpdateArtifactTool = toolCall.name === 'update_artifact'
+  const isArtifactMutationTool = isCreateArtifactTool || isUpdateArtifactTool
+
   const isExpandable = (() => {
-    if (toolCall.name === 'create_artifact' && !hasResult && !formattedResult?.isError) {
+    if (isArtifactMutationTool && !hasResult && !formattedResult?.isError) {
       return false
     }
     return true
   })()
 
-  // Get artifact info if this is a create_artifact call
-  const artifactTitle = toolCall.name === 'create_artifact' && toolCall.args?.title
+  // Get artifact info if this is a create/update artifact call
+  const artifactTitle = typeof toolCall.args?.title === 'string'
     ? String(toolCall.args.title)
     : null
-  const artifactType = toolCall.name === 'create_artifact' && toolCall.args?.type
+  const artifactType = typeof toolCall.args?.type === 'string'
     ? String(toolCall.args.type).toLowerCase()
     : null
-  const createdArtifact = artifactTitle
-    ? artifacts
-      .filter((artifact) => {
-        const titleMatches = artifact.title === artifactTitle
-        const conversationMatches = activeConversationId
-          ? artifact.conversationId === activeConversationId
-          : true
-        const typeMatches = artifactType
-          ? artifact.type.toLowerCase() === artifactType
-          : true
-        return titleMatches && conversationMatches && typeMatches
-      })
-      .sort((a, b) => b.updatedAt - a.updatedAt)[0] || null
-    : null
-  const createArtifactResult = toolCall.name === 'create_artifact' && toolResult?.result && typeof toolResult.result === 'object'
-    ? toolResult.result as Record<string, unknown>
-    : null
-  const thumbnailBase64 = typeof createArtifactResult?.thumbnailBase64 === 'string'
-    ? createArtifactResult.thumbnailBase64
-    : null
-  const thumbnailMimeType = typeof createArtifactResult?.thumbnailMimeType === 'string'
-    ? createArtifactResult.thumbnailMimeType
-    : 'image/jpeg'
-  const thumbnailDataUrl = thumbnailBase64
-    ? `data:${thumbnailMimeType};base64,${thumbnailBase64}`
+  const expectsHtmlThumbnail = artifactType === 'html'
+  const updateArtifactId = isUpdateArtifactTool && typeof toolCall.args?.id === 'string'
+    ? String(toolCall.args.id)
     : null
 
+  const linkedArtifact = (() => {
+    if (isCreateArtifactTool && artifactTitle) {
+      const matches = artifacts
+        .filter((artifact) => {
+          const titleMatches = artifact.title === artifactTitle
+          const conversationMatches = activeConversationId
+            ? artifact.conversationId === activeConversationId
+            : true
+          const typeMatches = artifactType
+            ? artifact.type.toLowerCase() === artifactType
+            : true
+          return titleMatches && conversationMatches && typeMatches
+        })
+        .sort((a, b) => b.updatedAt - a.updatedAt)
+      return matches[0] || null
+    }
+
+    if (isUpdateArtifactTool && updateArtifactId) {
+      const matches = artifacts
+        .filter((artifact) => {
+          const conversationMatches = activeConversationId
+            ? artifact.conversationId === activeConversationId
+            : true
+          if (!conversationMatches) return false
+          return artifact.id === updateArtifactId || artifact.baseArtifactId === updateArtifactId
+        })
+        .sort((a, b) => b.updatedAt - a.updatedAt)
+      return matches[0] || null
+    }
+
+    return null
+  })()
+
+  const artifactMutationResult = isArtifactMutationTool && toolResult?.result && typeof toolResult.result === 'object'
+    ? toolResult.result as Record<string, unknown>
+    : null
+  const thumbnailDataUrl = resolveArtifactThumbnailSource(artifactMutationResult)
+  const previewDataUrl = resolveArtifactPreviewSource(artifactMutationResult) || thumbnailDataUrl
+  const expandedPreviewUrl = (isPreviewFailed ? thumbnailDataUrl : previewDataUrl) || thumbnailDataUrl
+  const artifactLinkLabel = isCreateArtifactTool && linkedArtifact
+    ? linkedArtifact.title
+    : 'Open current artifact'
+
   const handleArtifactClick = () => {
-    if (createdArtifact) {
-      selectArtifact(createdArtifact.id)
+    if (linkedArtifact) {
+      selectArtifact(linkedArtifact.id)
       openCanvas()
     }
   }
+
+  useEffect(() => {
+    if (!isThumbnailOpen) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsThumbnailOpen(false)
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [isThumbnailOpen])
+
+  useEffect(() => {
+    setIsThumbnailOpen(false)
+    setIsThumbnailFailed(false)
+    setIsPreviewFailed(false)
+  }, [toolCall.id])
 
   return (
     <div className="border border-border rounded-lg overflow-hidden bg-bg-deep">
@@ -669,40 +794,52 @@ export function SingleToolCallDisplay({
         )}
       </button>
 
-      {/* Artifact creation in progress - simple indicator, no streaming preview */}
-      {toolCall.name === 'create_artifact' && !hasResult && (
+      {/* Artifact create/update in progress - simple indicator, no streaming preview */}
+      {isArtifactMutationTool && !hasResult && (
         <div className="px-3 py-2 border-t border-border bg-bg-surface">
           <span className="text-xs text-text-muted">
-            Creating {formatArtifactType()}...
+            {isCreateArtifactTool ? 'Creating ' : 'Updating '}
+            {formatArtifactType()}...
           </span>
         </div>
       )}
 
-      {/* Artifact link - shown inline when create_artifact completes */}
-      {toolCall.name === 'create_artifact' && hasResult && !formattedResult?.isError && createdArtifact && (
+      {/* Artifact link - shown inline when create/update completes */}
+      {isArtifactMutationTool && hasResult && !formattedResult?.isError && linkedArtifact && (
         <div className="px-3 py-2 border-t border-border bg-bg-surface">
           <button
             onClick={handleArtifactClick}
             className="flex items-center gap-2 text-xs text-accent hover:text-accent-bright transition-colors"
           >
             <ExternalLink className="w-3 h-3" />
-            <span className="underline">{createdArtifact.title}</span>
+            <span className="underline">{artifactLinkLabel}</span>
           </button>
         </div>
       )}
-      {toolCall.name === 'create_artifact' && hasResult && !formattedResult?.isError && thumbnailDataUrl && (
+      {isArtifactMutationTool && expectsHtmlThumbnail && hasResult && !formattedResult?.isError && thumbnailDataUrl && !isThumbnailFailed && (
         <div className="px-3 pb-3 border-t border-border bg-bg-surface">
           <button
-            onClick={() => setIsThumbnailOpen(true)}
+            onClick={() => {
+              setIsPreviewFailed(false)
+              setIsThumbnailOpen(true)
+            }}
             className="mt-2 rounded border border-border overflow-hidden hover:border-accent/70 transition-colors"
             aria-label="Open artifact thumbnail preview"
           >
             <img
               src={thumbnailDataUrl}
-              alt="HTML artifact thumbnail preview"
-              className="block w-full max-w-[300px] h-auto"
+              alt={isCreateArtifactTool ? 'HTML artifact thumbnail snapshot at creation' : 'HTML artifact thumbnail snapshot after update'}
+              className="block w-full max-w-[150px] h-auto"
+              onError={() => setIsThumbnailFailed(true)}
             />
           </button>
+        </div>
+      )}
+      {isArtifactMutationTool && expectsHtmlThumbnail && hasResult && !formattedResult?.isError && (!thumbnailDataUrl || isThumbnailFailed) && (
+        <div className="px-3 pb-3 border-t border-border bg-bg-surface">
+          <div className="mt-2 rounded border border-border bg-bg-deep px-2.5 py-2 text-xs text-text-muted">
+            Thumbnail preview unavailable.
+          </div>
         </div>
       )}
 
@@ -781,17 +918,34 @@ export function SingleToolCallDisplay({
         </div>
       )}
 
-      {isThumbnailOpen && thumbnailDataUrl && (
+      {isThumbnailOpen && expandedPreviewUrl && !isThumbnailFailed && (
         <div
           className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4"
           onClick={() => setIsThumbnailOpen(false)}
         >
-          <img
-            src={thumbnailDataUrl}
-            alt="Expanded HTML artifact thumbnail preview"
-            className="w-[70vw] max-h-[70vh] object-contain rounded shadow-2xl"
-            onClick={(event) => event.stopPropagation()}
-          />
+          <div className="relative" onClick={(event) => event.stopPropagation()}>
+            <button
+              type="button"
+              onClick={() => setIsThumbnailOpen(false)}
+              className="absolute -top-3 -right-3 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-border bg-bg-elevated text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors"
+              aria-label="Close preview"
+            >
+              <X className="w-4 h-4" />
+            </button>
+            <img
+              src={expandedPreviewUrl}
+              alt="Expanded HTML artifact thumbnail preview"
+              className="max-w-[90vw] max-h-[85vh] object-contain rounded shadow-2xl"
+              onError={() => {
+                if (!isPreviewFailed && previewDataUrl && thumbnailDataUrl && previewDataUrl !== thumbnailDataUrl) {
+                  setIsPreviewFailed(true)
+                  return
+                }
+                setIsThumbnailFailed(true)
+                setIsThumbnailOpen(false)
+              }}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,21 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.33.3',
+    date: '2026-02-25',
+    changes: {
+      fixed: [
+        'Chat attachment image previews now render reliably across common MIME/extension mismatches and malformed image payloads (Fixes #83)',
+        'HTML artifact thumbnail capture now waits for render settle, targets the primary visual surface, and preserves a higher-fidelity expandable preview',
+        'Artifact create/update preview cards now use a compact thumbnail, explicit close control, and safer fallback behavior when preview payloads fail to decode',
+        'Turn completion now validates artifact/file mutation claims against successful tool evidence and retries silently once before surfacing failure',
+      ],
+      changed: [
+        'Tool-call thumbnail previews now include update_artifact snapshots in addition to create_artifact output',
+      ],
+    },
+  },
+  {
     version: '0.33.2',
     date: '2026-02-24',
     changes: {


### PR DESCRIPTION
## Summary
- fix chat image attachment preview handling so image MIME/base64 edge cases do not render broken previews
- improve HTML artifact snapshot capture timing/area and include both thumbnail + higher-fidelity preview payloads
- make artifact create/update tool cards consistent: compact thumbnail, cleaner modal close UX, and fallback handling
- add deterministic completion validation so artifact/file mutation claims require successful tool evidence, with one silent repair pass
- bump version to `0.33.3` and update technical/user changelogs plus AGENTS metadata

## Testing
- `npx tsc --noEmit`
- Manual validation in app: create artifact, update artifact, thumbnail preview, expanded preview, image attachment preview

Fixes #83