### PR TITLE
v0.33.6: hotfix streaming response ordering with tool calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.33.5
+**Current Version:** 0.33.6
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Jelico are documented in this file.
 
+## [0.33.6] - 2026-02-28
+
+### Fixed
+- **Streaming Message Order** — Assistant progress text now appears in the right chronological order with tool activity instead of being delayed and dumped as a late block under completed actions.
+
+### Changed
+- **Live Response Flow** — Buffering for completion-sensitive turns is now limited to validation-retry paths, so normal turns stream naturally while tools run.
+
 ## [0.33.5] - 2026-02-28
 
 ### Fixed

--- a/electron/ipc/ai.ts
+++ b/electron/ipc/ai.ts
@@ -3777,10 +3777,9 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
         const attemptSystemPrompt = pendingCompletionRepairDirective
           ? `${systemPrompt}\n\n${pendingCompletionRepairDirective}`
           : systemPrompt
-        const shouldBufferCompletionSensitiveText =
-          expectedArtifactMutation ||
-          expectedFileMutation ||
-          !!pendingCompletionRepairDirective
+        // Preserve chronological UI ordering: stream assistant text live on normal turns.
+        // Only buffer during validation-repair retries so failed-attempt text isn't emitted.
+        const shouldBufferCompletionSensitiveText = !!pendingCompletionRepairDirective
 
         // Track step count for warning injection
         let stepCount = 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.33.5",
+      "version": "0.33.6",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,18 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.33.6',
+    date: '2026-02-28',
+    changes: {
+      fixed: [
+        'Assistant progress text now streams in chronological order with tool activity on normal turns, preventing delayed text blocks from appearing out of sequence under completed tool calls (Hotfix for streaming order regression)',
+      ],
+      changed: [
+        'Completion-sensitive text buffering is now limited to validation-repair retries, preserving live response flow for regular artifact/file turns',
+      ],
+    },
+  },
+  {
     version: '0.33.5',
     date: '2026-02-28',
     changes: {


### PR DESCRIPTION
## Summary
- Hotfixes out-of-order streamed assistant text during tool-heavy turns.
- Restores chronological text/tool interleaving so progress lines appear when they are generated.
- Limits completion-sensitive buffering to validation-repair retries only.
- Bumps release metadata and version to `0.33.6`.

## Validation
- `npx tsc --noEmit`

## Issues
- Fixes #8
