### PR TITLE
fix: live workspace branch updates during chat git switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Jelico are documented in this file.
 
+## [0.33.10] - 2026-03-03
+
+### Highlights
+- Branch changes made during an active chat now reflect immediately in the header branch badge after successful `git checkout` or `git switch` commands.
+
+### Fixed
+- **Live Branch Display During Chat** — When Jelico runs a successful branch switch command in an active chat, the workspace branch label now updates right away instead of showing stale branch context until restart.
+
 ## [0.33.9] - 2026-03-03
 
 ### Highlights

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.33.10',
+    date: '2026-03-03',
+    changes: {
+      fixed: [
+        'Active workspace branch indicator now refreshes live after successful in-chat git branch switches (`git checkout` / `git switch`) executed through the command tool (Fixes #81)',
+      ],
+    },
+  },
+  {
     version: '0.33.9',
     date: '2026-03-03',
     changes: {

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -57,6 +57,7 @@ export interface ToolResult {
 }
 
 const INTERNAL_WEB_GATE_RESULT_TYPES = new Set(['deferred_to_subagents', 'direct_limit_reached'])
+const GIT_BRANCH_SWITCH_COMMAND_PATTERN = /\bgit(?:\s+-c\s+\S+)*\s+(?:checkout|switch)\b/i
 
 function isInternalWebGateResultPayload(payload: unknown): boolean {
   if (!payload || typeof payload !== 'object') return false
@@ -65,6 +66,19 @@ function isInternalWebGateResultPayload(payload: unknown): boolean {
   const results = obj.results as Record<string, unknown> | undefined
   const resultType = typeof results?.type === 'string' ? results.type : ''
   return INTERNAL_WEB_GATE_RESULT_TYPES.has(resultType)
+}
+
+function shouldRefreshWorkspaceGitAfterCommand(toolCall: ToolCall | undefined, result: unknown): boolean {
+  if (!toolCall || toolCall.name !== 'execute_command') return false
+  if (!result || typeof result !== 'object') return false
+
+  const resultObj = result as Record<string, unknown>
+  if (resultObj.success !== true) return false
+
+  const command = toolCall.args?.command
+  if (typeof command !== 'string') return false
+
+  return GIT_BRANCH_SWITCH_COMMAND_PATTERN.test(command)
 }
 
 // Streaming segment - tracks content in the order it arrives
@@ -1329,12 +1343,18 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     window.jelico.ai.onToolResults(channelId, (toolResults) => {
       console.log('[Chat Store] Received tool results:', toolResults)
       const now = Date.now()
+      let shouldRefreshWorkspaceGit = false
 
       updateConversationStreamState((current) => {
         const hiddenToolCallIds = new Set<string>()
         for (const result of toolResults) {
           const matchingToolCall = current.streamingToolCalls.find(tc => tc.id === result.toolCallId)
           if (!matchingToolCall) continue
+
+          if (shouldRefreshWorkspaceGitAfterCommand(matchingToolCall, result.result)) {
+            shouldRefreshWorkspaceGit = true
+          }
+
           const isInternalWebGateCall =
             (matchingToolCall.name === 'web_search' || matchingToolCall.name === 'web_fetch') &&
             isInternalWebGateResultPayload(result.result)
@@ -1386,6 +1406,17 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           toolInputProgress: null,
         }
       })
+
+      if (shouldRefreshWorkspaceGit) {
+        const conversationWorkspaceId = get().conversations.find((conversation) => conversation.id === targetConversationId)?.workspaceId
+        const fallbackWorkspaceId = useWorkspaceStore.getState().activeWorkspaceId
+        const workspaceIdToRefresh = conversationWorkspaceId || fallbackWorkspaceId
+        if (workspaceIdToRefresh) {
+          void useWorkspaceStore.getState().refreshGit(workspaceIdToRefresh).catch((error) => {
+            console.error('Failed to refresh workspace git state after branch switch command:', error)
+          })
+        }
+      }
     })
 
     // Handle tool call updates - updates status and args for existing tool calls


### PR DESCRIPTION
## Summary
- Active chat sessions could report successful branch switches while the header still displayed the previous branch until app restart.

## Root Cause
- Workspace git metadata is refreshed on startup and manual refresh actions, but successful `execute_command` branch switches during streaming did not trigger a workspace git refresh.
- The header branch badge reads `activeWorkspace.gitBranch` from store state, so it stayed stale for the rest of the active chat lifecycle.

## Fix
- Detect successful `execute_command` results that run `git checkout` or `git switch` in chat tool-result handling.
- Trigger `refreshGit` for the conversation workspace immediately after those command results so workspace state and the header badge update live.

## Changes
- Added `shouldRefreshWorkspaceGitAfterCommand(...)` and git branch-switch command detection in `src/stores/chat.ts`.
- Updated tool-result processing in `src/stores/chat.ts` to call workspace `refreshGit` after successful branch-switch commands.
- Added technical changelog entry in `src/data/changelog.ts` for `0.33.10` with issue linkage.
- Added user-facing changelog entry in `CHANGELOG.md` describing immediate in-chat branch badge updates.

## Issue
Fixes #81
