### PR TITLE
feature: auto-create draft releases on main push for new versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       release:
@@ -122,7 +124,7 @@ jobs:
   release:
     needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release == 'true')
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release == 'true')
     env:
       MACOS_ARM_ARCH_LABEL: Apple Silicon (M-series)
     permissions:
@@ -140,13 +142,26 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts
 
-      - name: Get version from tag
+      - name: Resolve release tag
         id: version
         run: |
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            release_tag="${GITHUB_REF#refs/tags/}"
           else
-            echo "version=manual-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
+            package_version=$(node -p "require('./package.json').version")
+            release_tag="v${package_version}"
+          fi
+          echo "version=${release_tag}" >> $GITHUB_OUTPUT
+
+      - name: Check if release tag already exists
+        id: tag_check
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.version.outputs.version }} already exists. Skipping draft release creation."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate release note architecture labels
@@ -158,6 +173,7 @@ jobs:
           fi
 
       - name: Create Release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || steps.tag_check.outputs.exists != 'true' }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and
 - **Feature issue hygiene**: For feature work, create/update an issue titled `feature: <concise description>` and ensure the issue has the `enhancement` label
 - **PR title hygiene**: For bug-fix PRs, do not include version numbers in the PR title; keep the title focused on the bug behavior
 - **Template compliance**: When creating issues/PRs via AI, follow `.github/ISSUE_TEMPLATE/*` and `.github/PULL_REQUEST_TEMPLATE.md` exactly
+- **Draft PR gate check**: After creating or editing a draft PR, check GitHub Action `PR Format Check / validate-pr-body (pull_request)` and confirm it passes
+- **Draft PR corrective flow**: If `validate-pr-body` fails, inspect the run logs, correct the PR title/body/issue linkage and commit-message policy issues, then re-check until the action passes before requesting review
 - **GitHub tone hygiene**: Do not use emojis in GitHub-facing artifacts (issue titles/bodies, PR titles/bodies, commit messages, release notes)
 
 ## Version Bumping Protocol


### PR DESCRIPTION
## Summary
- Merged PRs to main were not creating draft releases automatically, requiring manual release follow-up.

## Root Cause
- The Build and Release workflow only triggered on * tag pushes or manual dispatch.
- No push trigger existed for main, so normal PR merges only ran CI and never entered release workflow.

## Fix
- Added push trigger for main in Build and Release workflow.
- Added version/tag resolution logic on non-tag runs to derive <package.json version> and skip release creation if that tag already exists.
- Added AGENTS guidance to explicitly check and correct PR Format Check / validate-pr-body failures on draft PRs.

## Changes
- Updated .github/workflows/build.yml to trigger on main pushes and gate draft release creation on tag existence.
- Updated release job conditions and version resolution to use semver tag format on non-tag runs.
- Updated AGENTS.md with required draft PR action-check and corrective flow steps.

## Issue
Fixes #117