### PR TITLE
fix: prevent intermittent prompt focus loss and restore composer top inset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.34.0
+**Current Version:** 0.34.1
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root
@@ -682,7 +682,7 @@ todo_write({ tasks: [
 - **Phase 1-7 Complete**: Core functionality, UI, artifacts, memory, soul system
 - **Phase 8 Complete**: Onboarding flow, backup/restore, versioning
 - **Current Focus**: Testing, polish, user feedback integration, and response finalization reliability
-- **Latest Patch (0.33.7)**: Streaming duplicate-restart prevention for transcript-heavy review prompts and completion-repair retries
+- **Latest Patch (0.34.1)**: Prompt focus/typing reliability hardening after clarification and improved top inset for long composer drafts
 
 ## Code style
 - TypeScript strict mode enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Jelico are documented in this file.
 
+## [0.34.1] - 2026-03-03
+
+### Highlights
+- Prompt input no longer intermittently loses focus after clarification or permission UI flows.
+- Long dictated or pasted drafts now maintain a clearer top inset in the prompt box while scrolling.
+
+### Fixed
+- **Prompt Focus Reliability** — The app now clears stale window-drag interaction state before new clicks and excludes composer and modal surfaces from drag handling, so the prompt remains clickable and editable.
+- **Prompt Top Padding** — Active chat composer spacing was adjusted to preserve visible top breathing room for multi-line dictation and long scrolling drafts.
+
 ## [0.34.0] - 2026-03-03
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,12 +207,15 @@ export default function App() {
   const handleAppMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     if (event.button !== 0) return
     if (event.detail > 1) return
+
+    // Always clear any stale drag session before deciding if this target
+    // should start a new one. This prevents "stuck" interaction guards from
+    // surviving clicks on interactive controls like the chat composer.
+    stopWindowDrag()
     if (isResizing) return
 
     const target = event.target as HTMLElement | null
     if (isInteractiveTarget(target)) return
-
-    stopWindowDrag()
 
     const onMouseMove = (moveEvent: MouseEvent) => {
       const dragSession = windowDragRef.current

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -118,7 +118,7 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
     textarea.style.height = 'auto'
     // Chat view (not centered): compact 1-line style, grows as needed
     // Welcome screen (centered): taller 4-line style
-    const minHeight = centered ? 96 : 64
+    const minHeight = centered ? 96 : 72
     const maxHeight = centered ? 200 : 150
     if (!content) {
       textarea.style.height = `${minHeight}px`
@@ -478,7 +478,7 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
   }, [handleSubmit])
 
   return (
-    <div className="space-y-0">
+    <div className="space-y-0" data-window-toggle="ignore">
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -628,8 +628,8 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
           }
           autoFocus
           rows={centered ? 4 : 2}
-          className={`flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none resize-none focus:outline-none focus:ring-0 border-none leading-6 px-3 pt-3 pb-0 scroll-pt-3 select-text ${
-            centered ? 'min-h-[96px] max-h-[200px]' : 'min-h-[64px] max-h-[150px]'
+          className={`flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-muted outline-none resize-none focus:outline-none focus:ring-0 border-none leading-6 px-3 pt-4 pb-0 scroll-pt-4 overflow-y-auto select-text ${
+            centered ? 'min-h-[96px] max-h-[200px]' : 'min-h-[72px] max-h-[150px]'
           }`}
         />
 

--- a/src/components/Clarification/ClarificationPanel.tsx
+++ b/src/components/Clarification/ClarificationPanel.tsx
@@ -294,6 +294,7 @@ export function ClarificationPanel() {
 
   return (
     <div
+      data-window-toggle="ignore"
       className="fixed inset-y-0 right-0 z-[45] flex items-center justify-center bg-bg-void/80 backdrop-blur-sm p-4"
       style={{ left: sidebarCollapsed ? 0 : '16rem' }}
     >

--- a/src/components/Permissions/PermissionDialog.tsx
+++ b/src/components/Permissions/PermissionDialog.tsx
@@ -68,7 +68,10 @@ export function PermissionDialog() {
     : null
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg-void/80 backdrop-blur-sm">
+    <div
+      data-window-toggle="ignore"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg-void/80 backdrop-blur-sm"
+    >
       <div className="bg-bg-surface border border-border rounded-xl shadow-xl max-w-lg w-full mx-4 overflow-hidden">
         {/* Header */}
         <div className="px-6 py-4 border-b border-border flex items-center gap-3">

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,16 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.34.1',
+    date: '2026-03-03',
+    changes: {
+      fixed: [
+        'Window-drag interaction guards now clear stale sessions before mousedown handling and ignore composer/clarification/permission surfaces, preventing intermittent prompt focus loss after modal interactions (Fixes #116)',
+        'Prompt textarea now uses a taller active-chat minimum height and stronger top inset so long dictated or pasted drafts do not appear flush against the top border while scrolling (Fixes #95)',
+      ],
+    },
+  },
+  {
     version: '0.34.0',
     date: '2026-03-03',
     changes: {


### PR DESCRIPTION
## Summary
- Prompt editing could intermittently become non-interactive after clarification and permission flows, and long prompt drafts could appear pressed against the top edge while scrolling.

## Root Cause
- App-level window-drag guards could retain stale interaction state long enough to intercept subsequent clicks in composer-adjacent flows, and composer spacing in active chat mode was too tight for long dictation and paste editing.

## Fix
- Hardened drag-session cleanup at app mousedown boundaries and explicitly excluded composer, clarification, and permission surfaces from window-drag handling.
- Increased active-chat composer minimum height and top inset to preserve readable top breathing room during long scrolling drafts.

## Changes
- Updated app interaction handling in src/App.tsx to clear stale drag state before mousedown target gating.
- Marked composer and modal overlays as drag-ignore surfaces in src/components/Chat/ChatInput.tsx, src/components/Clarification/ClarificationPanel.tsx, and src/components/Permissions/PermissionDialog.tsx.
- Adjusted chat composer textarea spacing and sizing in src/components/Chat/ChatInput.tsx.
- Added release notes and technical changelog entries, bumped version to 0.34.1, and updated AGENTS.md current version and latest patch metadata.

## Issue
Fixes #95
Fixes #116