### PR TITLE
Fix release metadata and trigger patch release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.35.0
+**Current Version:** 0.35.1
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root
@@ -686,7 +686,7 @@ todo_write({ tasks: [
 - **Phase 1-7 Complete**: Core functionality, UI, artifacts, memory, soul system
 - **Phase 8 Complete**: Onboarding flow, backup/restore, versioning
 - **Current Focus**: Testing, polish, user feedback integration, and release hardening across tool UX and workspace flows
-- **Latest Release (0.35.0)**: Enhancement sweep covering archive/restore conversation workflow, update availability/apply toast flow, default-browser link handling, artifact screenshot capture, tool-call consolidation, widened single-pane chat layout, content search tooling, capability-profile routing, and shared task-graph coordination
+- **Latest Release (0.35.1)**: Patch release focused on interrupted artifact/file workflows, adding provider-side interruption labeling, deterministic recovery for incomplete mutation turns, and safer completion-sensitive streaming/restart handling
 
 ## Code style
 - TypeScript strict mode enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.35.1] - 2026-03-07
+## [0.35.1] - 2026-03-09
 
 ### Highlights
 - Artifact and file tool runs that are interrupted by provider stream termination now show provider interruption context instead of looking like a local tool failure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -22,7 +22,7 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   {
     version: '0.35.1',
-    date: '2026-03-07',
+    date: '2026-03-09',
     changes: {
       fixed: [
         'Tool streams that end after `tool-input-start` now emit provider-interruption metadata instead of only synthetic local cancellation labels, so incomplete artifact/file workflows surface the original interruption cause clearly (Fixes #136)',


### PR DESCRIPTION
## Summary
- The merged interrupted-stream fix already updated the 0.35.1 changelog entries, but the repository version metadata stayed at 0.35.0, so the patch release never published.

## Root Cause
- The release gate in .github/workflows/build.yml only creates a release when a main push changes package.json's version.
- PR #137 merged without bumping package.json/package-lock.json or aligning AGENTS.md release metadata, leaving the repo in a split 0.35.0/0.35.1 state.

## Fix
- Apply the 0.35.1 patch version bump and align release metadata so the follow-up merge to main satisfies the release workflow.

## Changes
- Bumped package.json and package-lock.json from 0.35.0 to 0.35.1.
- Normalized the 0.35.1 changelog date to 2026-03-09 in CHANGELOG.md and src/data/changelog.ts.
- Updated AGENTS.md current version and latest release references for the 0.35.1 patch.

## Issue
Fixes #138