### PR TITLE
Resolve provider-specific Kimi model limits for compatible providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.35.2] - 2026-03-09
+
+### Highlights
+- Kimi coding endpoints that expose provider-specific model names now resolve to the correct model limits instead of falling back to generic provider defaults.
+- Large artifact generations on compatible Kimi providers are less likely to truncate when the endpoint uses a service-specific model name such as `kimi-for-coding`.
+
+### Fixed
+- **Provider-Specific Kimi Names** — Anthropic-compatible Kimi endpoints that return names like `kimi-for-coding` now map to the correct underlying Kimi model metadata, so Jelico can apply the right context and output limits.
+- **Artifact Truncation on Kimi Coding Plans** — Large HTML artifact turns on Kimi coding providers now inherit the expected output cap instead of relying on an opaque provider default when the endpoint uses a provider-defined model name.
+
+### Changed
+- **Compatible Model Resolution** — Jelico now uses compatible-provider endpoint metadata together with the selected model name when resolving model capabilities and limits from models.dev.
+
 ## [0.35.1] - 2026-03-09
 
 ### Highlights

--- a/electron/ipc/ai.ts
+++ b/electron/ipc/ai.ts
@@ -1129,7 +1129,10 @@ async function resolveProviderMaxOutputTokens(providerConfig: any, modelId: stri
 
   try {
     await refreshModelCatalog(false)
-    const limit = lookupModelsDevOutputLimit(providerConfig.type, normalizedModel)
+    const limit = lookupModelsDevOutputLimit(providerConfig.type, normalizedModel, {
+      baseUrl: providerConfig.base_url,
+      providerName: providerConfig.name,
+    })
     if (limit && Number.isFinite(limit) && limit > 0) {
       return Math.round(limit)
     }
@@ -3905,7 +3908,10 @@ export function registerAIHandlers() {
       const projectConversationContext = buildProjectConversationContext(params.conversationId)
       const useLeanPromptDefault = process.env.JELICO_FULL_PROMPT !== '1'
       const providerProfileOverrides = ((providerConfig as any).capability_profiles || null) as Record<string, any> | null
-      const modelsDevMetadata = lookupModelsDevModelMetadata(providerConfig.type, modelId)
+      const modelsDevMetadata = lookupModelsDevModelMetadata(providerConfig.type, modelId, {
+        baseUrl: providerConfig.base_url,
+        providerName: providerConfig.name,
+      })
       const modelCapabilityProfile = resolveModelCapabilityProfile({
         providerType: providerConfig.type,
         modelId,

--- a/electron/ipc/providers.ts
+++ b/electron/ipc/providers.ts
@@ -878,7 +878,10 @@ export function registerProviderHandlers() {
 
       // Keep catalog fresh and prefer models.dev when available.
       await refreshModelCatalog(false)
-      const fromModelsDev = lookupModelsDevContextLimit(provider.type, modelId)
+      const fromModelsDev = lookupModelsDevContextLimit(provider.type, modelId, {
+        baseUrl,
+        providerName: provider.name,
+      })
       if (fromModelsDev) {
         return fromModelsDev
       }

--- a/electron/services/modelCatalog.ts
+++ b/electron/services/modelCatalog.ts
@@ -1,26 +1,18 @@
 import { app } from 'electron'
 import fs from 'fs'
 import path from 'path'
+import {
+  buildModelsDevIndexes,
+  type ModelsDevIndexes,
+  type ModelsDevLookupOptions,
+  type ModelsDevModelMetadata,
+  lookupModelsDevContextLimitInIndexes,
+  lookupModelsDevModelMetadataInIndexes,
+  lookupModelsDevOutputLimitInIndexes,
+} from './modelsDevResolver'
 
 const MODELS_DEV_URL = 'https://models.dev/api.json'
 const CATALOG_REFRESH_TTL_MS = 6 * 60 * 60 * 1000 // 6h
-
-const PROVIDER_TYPE_TO_MODELS_DEV_KEYS: Record<string, string[]> = {
-  anthropic: ['anthropic'],
-  openai: ['openai'],
-  google: ['google'],
-  openrouter: ['openrouter'],
-  ollama: ['ollama'],
-  local: ['lmstudio', 'ollama'],
-  minimax: ['minimax', 'minimax-coding-plan', 'minimax-cn', 'minimax-cn-coding-plan'],
-  zai: ['zai', 'zhipuai'],
-  'zai-china': ['zai', 'zhipuai'],
-  'zai-coding': ['zai-coding-plan', 'zhipuai-coding-plan', 'zai', 'zhipuai'],
-  'zai-coding-china': ['zai-coding-plan', 'zhipuai-coding-plan', 'zai', 'zhipuai'],
-  custom: [],
-  'openai-compatible': [],
-  'anthropic-compatible': [],
-}
 
 interface ModelCatalogSnapshot {
   etag?: string | null
@@ -29,191 +21,21 @@ interface ModelCatalogSnapshot {
   providers: Record<string, unknown>
 }
 
-export interface ModelsDevModelMetadata {
-  providerKey: string
-  modelKey: string
-  modelId: string
-  family?: string | null
-  reasoning: boolean | null
-  toolCall: boolean | null
-}
-
-function normalize(value: string): string {
-  return value.trim().toLowerCase()
-}
-
-function shortModelId(modelId: string): string {
-  const normalized = normalize(modelId)
-  const parts = normalized.split('/')
-  return parts[parts.length - 1] || normalized
-}
-
 function getCatalogCachePath(): string {
   return path.join(app.getPath('userData'), 'models-dev-catalog.json')
 }
 
-function toPositiveNumber(value: unknown): number | null {
-  const numeric = Number(value)
-  if (!Number.isFinite(numeric) || numeric <= 0) return null
-  return Math.round(numeric)
-}
-
-function extractContextLimit(model: any): number | null {
-  const candidates = [
-    model?.limit?.context,
-    model?.limit?.input,
-    model?.context_length,
-    model?.contextLength,
-    model?.max_context_length,
-    model?.maxContextLength,
-    model?.input_token_limit,
-    model?.inputTokenLimit,
-    model?.max_input_tokens,
-    model?.maxInputTokens,
-    model?.limits?.context_window,
-    model?.limits?.contextLength,
-    model?.architecture?.context_length,
-    model?.metadata?.context_length,
-  ]
-
-  for (const candidate of candidates) {
-    const size = toPositiveNumber(candidate)
-    if (size) return size
-  }
-
-  return null
-}
-
-function extractOutputLimit(model: any): number | null {
-  const candidates = [
-    model?.limit?.output,
-    model?.output_token_limit,
-    model?.outputTokenLimit,
-    model?.max_output_tokens,
-    model?.maxOutputTokens,
-    model?.limits?.output,
-    model?.limits?.output_tokens,
-    model?.metadata?.output_tokens,
-  ]
-
-  for (const candidate of candidates) {
-    const size = toPositiveNumber(candidate)
-    if (size) return size
-  }
-
-  return null
-}
-
 let initialized = false
 let inMemoryProviders: Record<string, unknown> | null = null
-let providerModelIndex = new Map<string, Map<string, number>>()
-let globalModelIndex = new Map<string, number>()
-let providerModelOutputIndex = new Map<string, Map<string, number>>()
-let globalModelOutputIndex = new Map<string, number>()
-let providerModelMetadataIndex = new Map<string, Map<string, ModelsDevModelMetadata>>()
-let globalModelMetadataIndex = new Map<string, ModelsDevModelMetadata>()
+let indexes: ModelsDevIndexes = buildModelsDevIndexes({})
 let etag: string | null = null
 let lastCheckedAt = 0
 let lastUpdatedAt = 0
 let refreshInFlight: Promise<void> | null = null
 let refreshTimer: NodeJS.Timeout | null = null
 
-function indexModelId(target: Map<string, number>, id: string, contextLimit: number) {
-  const normalized = normalize(id)
-  if (!normalized) return
-
-  const previous = target.get(normalized)
-  if (!previous || contextLimit > previous) {
-    target.set(normalized, contextLimit)
-  }
-}
-
-function indexModelMetadata(
-  target: Map<string, ModelsDevModelMetadata>,
-  id: string,
-  metadata: ModelsDevModelMetadata
-) {
-  const normalized = normalize(id)
-  if (!normalized) return
-  if (!target.has(normalized)) {
-    target.set(normalized, metadata)
-  }
-}
-
 function rebuildIndexes(providers: Record<string, unknown>) {
-  providerModelIndex = new Map()
-  globalModelIndex = new Map()
-  providerModelOutputIndex = new Map()
-  globalModelOutputIndex = new Map()
-  providerModelMetadataIndex = new Map()
-  globalModelMetadataIndex = new Map()
-
-  for (const [providerKey, providerValue] of Object.entries(providers)) {
-    if (!providerValue || typeof providerValue !== 'object') continue
-
-    const providerRecord = providerValue as Record<string, unknown>
-    const models = providerRecord.models
-    if (!models || typeof models !== 'object') continue
-
-    const providerMap = new Map<string, number>()
-    const providerOutputMap = new Map<string, number>()
-    const providerMetadataMap = new Map<string, ModelsDevModelMetadata>()
-
-    for (const [modelKey, modelValue] of Object.entries(models as Record<string, unknown>)) {
-      if (!modelValue || typeof modelValue !== 'object') continue
-
-      const modelRecord = modelValue as Record<string, unknown>
-      const contextLimit = extractContextLimit(modelRecord)
-      const outputLimit = extractOutputLimit(modelRecord)
-
-      const ids = new Set<string>()
-      ids.add(modelKey)
-      if (typeof modelRecord.id === 'string') ids.add(modelRecord.id)
-
-      const metadata: ModelsDevModelMetadata = {
-        providerKey: normalize(providerKey),
-        modelKey,
-        modelId: typeof modelRecord.id === 'string' ? modelRecord.id : modelKey,
-        family: typeof modelRecord.family === 'string' ? modelRecord.family : null,
-        reasoning: typeof modelRecord.reasoning === 'boolean' ? modelRecord.reasoning : null,
-        toolCall: typeof modelRecord.tool_call === 'boolean' ? modelRecord.tool_call : null,
-      }
-
-      for (const id of ids) {
-        if (contextLimit) {
-          indexModelId(providerMap, id, contextLimit)
-          indexModelId(globalModelIndex, id, contextLimit)
-        }
-
-        if (outputLimit) {
-          indexModelId(providerOutputMap, id, outputLimit)
-          indexModelId(globalModelOutputIndex, id, outputLimit)
-        }
-
-        indexModelMetadata(providerMetadataMap, id, metadata)
-        indexModelMetadata(globalModelMetadataIndex, id, metadata)
-
-        const shortId = shortModelId(id)
-        if (shortId && shortId !== normalize(id)) {
-          if (contextLimit) {
-            indexModelId(providerMap, shortId, contextLimit)
-            indexModelId(globalModelIndex, shortId, contextLimit)
-          }
-          if (outputLimit) {
-            indexModelId(providerOutputMap, shortId, outputLimit)
-            indexModelId(globalModelOutputIndex, shortId, outputLimit)
-          }
-
-          indexModelMetadata(providerMetadataMap, shortId, metadata)
-          indexModelMetadata(globalModelMetadataIndex, shortId, metadata)
-        }
-      }
-    }
-
-    providerModelIndex.set(normalize(providerKey), providerMap)
-    providerModelOutputIndex.set(normalize(providerKey), providerOutputMap)
-    providerModelMetadataIndex.set(normalize(providerKey), providerMetadataMap)
-  }
+  indexes = buildModelsDevIndexes(providers)
 }
 
 function persistSnapshot() {
@@ -304,83 +126,31 @@ export async function refreshModelCatalog(force = false): Promise<void> {
   return refreshInFlight
 }
 
-function getProviderCandidates(providerType: string): string[] {
-  const normalizedType = normalize(providerType)
-  const mapped = PROVIDER_TYPE_TO_MODELS_DEV_KEYS[normalizedType] || []
-  const candidates = new Set<string>([normalizedType, ...mapped])
-  return [...candidates]
-}
-
-function lookupInProviderIndex(providerKey: string, modelId: string): number | null {
-  const providerMap = providerModelIndex.get(normalize(providerKey))
-  if (!providerMap) return null
-
-  const normalizedModelId = normalize(modelId)
-  const shortId = shortModelId(modelId)
-
-  return providerMap.get(normalizedModelId) ?? providerMap.get(shortId) ?? null
-}
-
-function lookupInProviderOutputIndex(providerKey: string, modelId: string): number | null {
-  const providerMap = providerModelOutputIndex.get(normalize(providerKey))
-  if (!providerMap) return null
-
-  const normalizedModelId = normalize(modelId)
-  const shortId = shortModelId(modelId)
-
-  return providerMap.get(normalizedModelId) ?? providerMap.get(shortId) ?? null
-}
-
-function lookupInProviderMetadataIndex(providerKey: string, modelId: string): ModelsDevModelMetadata | null {
-  const providerMap = providerModelMetadataIndex.get(normalize(providerKey))
-  if (!providerMap) return null
-
-  const normalizedModelId = normalize(modelId)
-  const shortId = shortModelId(modelId)
-
-  return providerMap.get(normalizedModelId) ?? providerMap.get(shortId) ?? null
-}
-
-export function lookupModelsDevContextLimit(providerType: string, modelId: string): number | null {
+export function lookupModelsDevContextLimit(
+  providerType: string,
+  modelId: string,
+  options?: ModelsDevLookupOptions
+): number | null {
   if (!inMemoryProviders || !modelId) return null
-
-  for (const providerKey of getProviderCandidates(providerType)) {
-    const fromProvider = lookupInProviderIndex(providerKey, modelId)
-    if (fromProvider) return fromProvider
-  }
-
-  const normalizedModelId = normalize(modelId)
-  const shortId = shortModelId(modelId)
-  return globalModelIndex.get(normalizedModelId) ?? globalModelIndex.get(shortId) ?? null
+  return lookupModelsDevContextLimitInIndexes(indexes, providerType, modelId, options)
 }
 
-export function lookupModelsDevOutputLimit(providerType: string, modelId: string): number | null {
+export function lookupModelsDevOutputLimit(
+  providerType: string,
+  modelId: string,
+  options?: ModelsDevLookupOptions
+): number | null {
   if (!inMemoryProviders || !modelId) return null
-
-  for (const providerKey of getProviderCandidates(providerType)) {
-    const fromProvider = lookupInProviderOutputIndex(providerKey, modelId)
-    if (fromProvider) return fromProvider
-  }
-
-  const normalizedModelId = normalize(modelId)
-  const shortId = shortModelId(modelId)
-  return globalModelOutputIndex.get(normalizedModelId) ?? globalModelOutputIndex.get(shortId) ?? null
+  return lookupModelsDevOutputLimitInIndexes(indexes, providerType, modelId, options)
 }
 
 export function lookupModelsDevModelMetadata(
   providerType: string,
-  modelId: string
+  modelId: string,
+  options?: ModelsDevLookupOptions
 ): ModelsDevModelMetadata | null {
   if (!inMemoryProviders || !modelId) return null
-
-  for (const providerKey of getProviderCandidates(providerType)) {
-    const fromProvider = lookupInProviderMetadataIndex(providerKey, modelId)
-    if (fromProvider) return fromProvider
-  }
-
-  const normalizedModelId = normalize(modelId)
-  const shortId = shortModelId(modelId)
-  return globalModelMetadataIndex.get(normalizedModelId) ?? globalModelMetadataIndex.get(shortId) ?? null
+  return lookupModelsDevModelMetadataInIndexes(indexes, providerType, modelId, options)
 }
 
 export function initializeModelCatalog() {
@@ -400,10 +170,10 @@ export function initializeModelCatalog() {
 export function getModelCatalogStatus() {
   return {
     hasSnapshot: Boolean(inMemoryProviders),
-    providersIndexed: providerModelIndex.size,
-    modelsIndexed: globalModelIndex.size,
-    outputModelsIndexed: globalModelOutputIndex.size,
-    metadataModelsIndexed: globalModelMetadataIndex.size,
+    providersIndexed: indexes.providerModelIndex.size,
+    modelsIndexed: indexes.globalModelIndex.size,
+    outputModelsIndexed: indexes.globalModelOutputIndex.size,
+    metadataModelsIndexed: indexes.globalModelMetadataIndex.size,
     lastCheckedAt,
     lastUpdatedAt,
   }

--- a/electron/services/modelsDevResolver.test.ts
+++ b/electron/services/modelsDevResolver.test.ts
@@ -1,0 +1,98 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildModelsDevIndexes,
+  lookupModelsDevContextLimitInIndexes,
+  lookupModelsDevModelMetadataInIndexes,
+  lookupModelsDevOutputLimitInIndexes,
+} from './modelsDevResolver'
+
+const indexes = buildModelsDevIndexes({
+  'kimi-for-coding': {
+    id: 'kimi-for-coding',
+    name: 'Kimi For Coding',
+    api: 'https://api.kimi.com/coding/v1',
+    models: {
+      k2p5: {
+        id: 'k2p5',
+        name: 'Kimi K2.5',
+        reasoning: true,
+        tool_call: true,
+        release_date: '2026-01',
+        last_updated: '2026-01',
+        limit: {
+          context: 262144,
+          output: 32768,
+        },
+      },
+      'kimi-k2-thinking': {
+        id: 'kimi-k2-thinking',
+        name: 'Kimi K2 Thinking',
+        reasoning: true,
+        tool_call: true,
+        release_date: '2025-11',
+        last_updated: '2025-12',
+        limit: {
+          context: 262144,
+          output: 32768,
+        },
+      },
+    },
+  },
+})
+
+test('provider-specific model ids can resolve to preferred provider models', () => {
+  assert.equal(
+    lookupModelsDevOutputLimitInIndexes(indexes, 'anthropic-compatible', 'kimi-for-coding'),
+    32768
+  )
+  assert.equal(
+    lookupModelsDevContextLimitInIndexes(indexes, 'anthropic-compatible', 'kimi-for-coding'),
+    262144
+  )
+
+  const metadata = lookupModelsDevModelMetadataInIndexes(
+    indexes,
+    'anthropic-compatible',
+    'kimi-for-coding'
+  )
+  assert.equal(metadata?.providerKey, 'kimi-for-coding')
+  assert.equal(metadata?.modelId, 'k2p5')
+})
+
+test('direct model ids continue to win over provider-key alias fallback', () => {
+  const metadata = lookupModelsDevModelMetadataInIndexes(
+    indexes,
+    'anthropic-compatible',
+    'kimi-k2-thinking',
+    {
+      baseUrl: 'https://api.kimi.com/coding/v1/messages',
+      providerName: 'Kimi For Coding',
+    }
+  )
+
+  assert.equal(metadata?.modelId, 'kimi-k2-thinking')
+  assert.equal(metadata?.toolCall, true)
+})
+
+test('compatible provider base URLs can anchor provider-specific names to models.dev providers', () => {
+  const metadata = lookupModelsDevModelMetadataInIndexes(
+    indexes,
+    'anthropic-compatible',
+    'Kimi For Coding',
+    {
+      baseUrl: 'https://api.kimi.com/coding',
+      providerName: 'Kimi For Coding',
+    }
+  )
+
+  assert.equal(metadata?.providerKey, 'kimi-for-coding')
+  assert.equal(metadata?.modelId, 'k2p5')
+  assert.equal(
+    lookupModelsDevOutputLimitInIndexes(indexes, 'anthropic-compatible', 'Kimi For Coding', {
+      baseUrl: 'https://api.kimi.com/coding',
+      providerName: 'Kimi For Coding',
+    }),
+    32768
+  )
+})

--- a/electron/services/modelsDevResolver.ts
+++ b/electron/services/modelsDevResolver.ts
@@ -1,0 +1,492 @@
+export const PROVIDER_TYPE_TO_MODELS_DEV_KEYS: Record<string, string[]> = {
+  anthropic: ['anthropic'],
+  openai: ['openai'],
+  google: ['google'],
+  openrouter: ['openrouter'],
+  ollama: ['ollama'],
+  local: ['lmstudio', 'ollama'],
+  minimax: ['minimax', 'minimax-coding-plan', 'minimax-cn', 'minimax-cn-coding-plan'],
+  zai: ['zai', 'zhipuai'],
+  'zai-china': ['zai', 'zhipuai'],
+  'zai-coding': ['zai-coding-plan', 'zhipuai-coding-plan', 'zai', 'zhipuai'],
+  'zai-coding-china': ['zai-coding-plan', 'zhipuai-coding-plan', 'zai', 'zhipuai'],
+  custom: [],
+  'openai-compatible': [],
+  'anthropic-compatible': [],
+}
+
+export interface ModelsDevModelMetadata {
+  providerKey: string
+  modelKey: string
+  modelId: string
+  family?: string | null
+  reasoning: boolean | null
+  toolCall: boolean | null
+}
+
+export interface ModelsDevLookupOptions {
+  baseUrl?: string | null
+  providerName?: string | null
+}
+
+interface IndexedProviderRecord {
+  apiUrl: string | null
+  key: string
+  name: string | null
+  nameSlug: string | null
+  normalizedName: string | null
+  preferredModelIds: string[]
+}
+
+export interface ModelsDevIndexes {
+  globalModelIndex: Map<string, number>
+  globalModelMetadataIndex: Map<string, ModelsDevModelMetadata>
+  globalModelOutputIndex: Map<string, number>
+  providerModelIndex: Map<string, Map<string, number>>
+  providerModelMetadataIndex: Map<string, Map<string, ModelsDevModelMetadata>>
+  providerModelOutputIndex: Map<string, Map<string, number>>
+  providerRecords: Map<string, IndexedProviderRecord>
+}
+
+export function normalize(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function shortModelId(modelId: string): string {
+  const normalized = normalize(modelId)
+  const parts = normalized.split('/')
+  return parts[parts.length - 1] || normalized
+}
+
+function slugify(value: string): string {
+  return normalize(value)
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function normalizeApiUrl(value?: string | null): string | null {
+  const trimmed = String(value || '').trim()
+  if (!trimmed) return null
+
+  const stripTailSegments = (input: string) =>
+    input
+      .replace(/\/+(models|messages)$/i, '')
+      .replace(/\/+$/, '')
+
+  try {
+    const parsed = new URL(trimmed)
+    const pathname = stripTailSegments(parsed.pathname || '')
+    const normalizedPath = pathname ? pathname : ''
+    return `${parsed.origin.toLowerCase()}${normalizedPath}`
+  } catch {
+    return stripTailSegments(trimmed.toLowerCase())
+  }
+}
+
+function toPositiveNumber(value: unknown): number | null {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric) || numeric <= 0) return null
+  return Math.round(numeric)
+}
+
+function extractContextLimit(model: Record<string, unknown>): number | null {
+  const candidates = [
+    model.limit && typeof model.limit === 'object' ? (model.limit as Record<string, unknown>).context : null,
+    model.limit && typeof model.limit === 'object' ? (model.limit as Record<string, unknown>).input : null,
+    model.context_length,
+    model.contextLength,
+    model.max_context_length,
+    model.maxContextLength,
+    model.input_token_limit,
+    model.inputTokenLimit,
+    model.max_input_tokens,
+    model.maxInputTokens,
+    model.limits && typeof model.limits === 'object' ? (model.limits as Record<string, unknown>).context_window : null,
+    model.limits && typeof model.limits === 'object' ? (model.limits as Record<string, unknown>).contextLength : null,
+    model.architecture && typeof model.architecture === 'object' ? (model.architecture as Record<string, unknown>).context_length : null,
+    model.metadata && typeof model.metadata === 'object' ? (model.metadata as Record<string, unknown>).context_length : null,
+  ]
+
+  for (const candidate of candidates) {
+    const size = toPositiveNumber(candidate)
+    if (size) return size
+  }
+
+  return null
+}
+
+function extractOutputLimit(model: Record<string, unknown>): number | null {
+  const candidates = [
+    model.limit && typeof model.limit === 'object' ? (model.limit as Record<string, unknown>).output : null,
+    model.output_token_limit,
+    model.outputTokenLimit,
+    model.max_output_tokens,
+    model.maxOutputTokens,
+    model.limits && typeof model.limits === 'object' ? (model.limits as Record<string, unknown>).output : null,
+    model.limits && typeof model.limits === 'object' ? (model.limits as Record<string, unknown>).output_tokens : null,
+    model.metadata && typeof model.metadata === 'object' ? (model.metadata as Record<string, unknown>).output_tokens : null,
+  ]
+
+  for (const candidate of candidates) {
+    const size = toPositiveNumber(candidate)
+    if (size) return size
+  }
+
+  return null
+}
+
+function parseCatalogDate(value: unknown): number {
+  if (typeof value !== 'string') return 0
+  const trimmed = value.trim()
+  if (!trimmed) return 0
+
+  let normalizedValue = trimmed
+  if (/^\d{4}$/.test(trimmed)) {
+    normalizedValue = `${trimmed}-01-01`
+  } else if (/^\d{4}-\d{2}$/.test(trimmed)) {
+    normalizedValue = `${trimmed}-01`
+  }
+
+  const parsed = Date.parse(normalizedValue)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function compareProviderModels(
+  a: { contextLimit: number; id: string; lastUpdated: number; outputLimit: number; releaseDate: number; toolCall: boolean },
+  b: { contextLimit: number; id: string; lastUpdated: number; outputLimit: number; releaseDate: number; toolCall: boolean }
+): number {
+  if (a.releaseDate !== b.releaseDate) return b.releaseDate - a.releaseDate
+  if (a.lastUpdated !== b.lastUpdated) return b.lastUpdated - a.lastUpdated
+  if (a.outputLimit !== b.outputLimit) return b.outputLimit - a.outputLimit
+  if (a.contextLimit !== b.contextLimit) return b.contextLimit - a.contextLimit
+  if (a.toolCall !== b.toolCall) return Number(b.toolCall) - Number(a.toolCall)
+  return a.id.localeCompare(b.id)
+}
+
+function indexModelId(target: Map<string, number>, id: string, limit: number) {
+  const normalizedId = normalize(id)
+  if (!normalizedId) return
+
+  const previous = target.get(normalizedId)
+  if (!previous || limit > previous) {
+    target.set(normalizedId, limit)
+  }
+}
+
+function indexModelMetadata(
+  target: Map<string, ModelsDevModelMetadata>,
+  id: string,
+  metadata: ModelsDevModelMetadata
+) {
+  const normalizedId = normalize(id)
+  if (!normalizedId) return
+  if (!target.has(normalizedId)) {
+    target.set(normalizedId, metadata)
+  }
+}
+
+export function buildModelsDevIndexes(providers: Record<string, unknown>): ModelsDevIndexes {
+  const providerModelIndex = new Map<string, Map<string, number>>()
+  const globalModelIndex = new Map<string, number>()
+  const providerModelOutputIndex = new Map<string, Map<string, number>>()
+  const globalModelOutputIndex = new Map<string, number>()
+  const providerModelMetadataIndex = new Map<string, Map<string, ModelsDevModelMetadata>>()
+  const globalModelMetadataIndex = new Map<string, ModelsDevModelMetadata>()
+  const providerRecords = new Map<string, IndexedProviderRecord>()
+
+  for (const [providerKey, providerValue] of Object.entries(providers)) {
+    if (!providerValue || typeof providerValue !== 'object') continue
+
+    const normalizedProviderKey = normalize(providerKey)
+    const providerRecord = providerValue as Record<string, unknown>
+    const models = providerRecord.models
+    if (!models || typeof models !== 'object') continue
+
+    const providerMap = new Map<string, number>()
+    const providerOutputMap = new Map<string, number>()
+    const providerMetadataMap = new Map<string, ModelsDevModelMetadata>()
+    const preferredModels: Array<{
+      contextLimit: number
+      id: string
+      lastUpdated: number
+      outputLimit: number
+      releaseDate: number
+      toolCall: boolean
+    }> = []
+
+    for (const [modelKey, modelValue] of Object.entries(models as Record<string, unknown>)) {
+      if (!modelValue || typeof modelValue !== 'object') continue
+
+      const modelRecord = modelValue as Record<string, unknown>
+      const contextLimit = extractContextLimit(modelRecord)
+      const outputLimit = extractOutputLimit(modelRecord)
+      const modelId = typeof modelRecord.id === 'string' ? modelRecord.id : modelKey
+
+      preferredModels.push({
+        contextLimit: contextLimit || 0,
+        id: modelId,
+        lastUpdated: parseCatalogDate(modelRecord.last_updated),
+        outputLimit: outputLimit || 0,
+        releaseDate: parseCatalogDate(modelRecord.release_date),
+        toolCall: modelRecord.tool_call === true,
+      })
+
+      const ids = new Set<string>([modelKey])
+      if (typeof modelRecord.id === 'string') ids.add(modelRecord.id)
+
+      const metadata: ModelsDevModelMetadata = {
+        providerKey: normalizedProviderKey,
+        modelKey,
+        modelId,
+        family: typeof modelRecord.family === 'string' ? modelRecord.family : null,
+        reasoning: typeof modelRecord.reasoning === 'boolean' ? modelRecord.reasoning : null,
+        toolCall: typeof modelRecord.tool_call === 'boolean' ? modelRecord.tool_call : null,
+      }
+
+      for (const id of ids) {
+        if (contextLimit) {
+          indexModelId(providerMap, id, contextLimit)
+          indexModelId(globalModelIndex, id, contextLimit)
+        }
+
+        if (outputLimit) {
+          indexModelId(providerOutputMap, id, outputLimit)
+          indexModelId(globalModelOutputIndex, id, outputLimit)
+        }
+
+        indexModelMetadata(providerMetadataMap, id, metadata)
+        indexModelMetadata(globalModelMetadataIndex, id, metadata)
+
+        const shortId = shortModelId(id)
+        if (shortId && shortId !== normalize(id)) {
+          if (contextLimit) {
+            indexModelId(providerMap, shortId, contextLimit)
+            indexModelId(globalModelIndex, shortId, contextLimit)
+          }
+
+          if (outputLimit) {
+            indexModelId(providerOutputMap, shortId, outputLimit)
+            indexModelId(globalModelOutputIndex, shortId, outputLimit)
+          }
+
+          indexModelMetadata(providerMetadataMap, shortId, metadata)
+          indexModelMetadata(globalModelMetadataIndex, shortId, metadata)
+        }
+      }
+    }
+
+    preferredModels.sort(compareProviderModels)
+
+    providerRecords.set(normalizedProviderKey, {
+      apiUrl: normalizeApiUrl(typeof providerRecord.api === 'string' ? providerRecord.api : null),
+      key: normalizedProviderKey,
+      name: typeof providerRecord.name === 'string' ? providerRecord.name : null,
+      nameSlug: typeof providerRecord.name === 'string' ? slugify(providerRecord.name) : null,
+      normalizedName: typeof providerRecord.name === 'string' ? normalize(providerRecord.name) : null,
+      preferredModelIds: preferredModels.map((model) => model.id),
+    })
+
+    providerModelIndex.set(normalizedProviderKey, providerMap)
+    providerModelOutputIndex.set(normalizedProviderKey, providerOutputMap)
+    providerModelMetadataIndex.set(normalizedProviderKey, providerMetadataMap)
+  }
+
+  return {
+    globalModelIndex,
+    globalModelMetadataIndex,
+    globalModelOutputIndex,
+    providerModelIndex,
+    providerModelMetadataIndex,
+    providerModelOutputIndex,
+    providerRecords,
+  }
+}
+
+function getProviderCandidates(
+  indexes: ModelsDevIndexes,
+  providerType: string,
+  modelId: string,
+  options?: ModelsDevLookupOptions
+): string[] {
+  const normalizedType = normalize(providerType)
+  const candidates = new Set<string>([normalizedType, ...(PROVIDER_TYPE_TO_MODELS_DEV_KEYS[normalizedType] || [])])
+
+  const normalizedModelId = normalize(modelId)
+  const shortId = shortModelId(modelId)
+
+  if (indexes.providerRecords.has(normalizedModelId)) {
+    candidates.add(normalizedModelId)
+  }
+
+  if (indexes.providerRecords.has(shortId)) {
+    candidates.add(shortId)
+  }
+
+  const providerName = String(options?.providerName || '').trim()
+  if (providerName) {
+    const normalizedName = normalize(providerName)
+    const sluggedName = slugify(providerName)
+
+    for (const providerRecord of indexes.providerRecords.values()) {
+      if (
+        providerRecord.normalizedName === normalizedName ||
+        (sluggedName && providerRecord.nameSlug === sluggedName)
+      ) {
+        candidates.add(providerRecord.key)
+      }
+    }
+  }
+
+  const normalizedBaseUrl = normalizeApiUrl(options?.baseUrl)
+  if (normalizedBaseUrl) {
+    for (const providerRecord of indexes.providerRecords.values()) {
+      if (!providerRecord.apiUrl) continue
+
+      if (
+        normalizedBaseUrl === providerRecord.apiUrl ||
+        normalizedBaseUrl.startsWith(providerRecord.apiUrl) ||
+        providerRecord.apiUrl.startsWith(normalizedBaseUrl)
+      ) {
+        candidates.add(providerRecord.key)
+      }
+    }
+  }
+
+  return [...candidates]
+}
+
+function lookupInProviderIndex(
+  providerIndex: Map<string, Map<string, number>>,
+  providerKey: string,
+  modelId: string
+): number | null {
+  const providerMap = providerIndex.get(normalize(providerKey))
+  if (!providerMap) return null
+
+  const normalizedModelId = normalize(modelId)
+  const shortId = shortModelId(modelId)
+  return providerMap.get(normalizedModelId) ?? providerMap.get(shortId) ?? null
+}
+
+function lookupInProviderMetadataIndex(
+  providerIndex: Map<string, Map<string, ModelsDevModelMetadata>>,
+  providerKey: string,
+  modelId: string
+): ModelsDevModelMetadata | null {
+  const providerMap = providerIndex.get(normalize(providerKey))
+  if (!providerMap) return null
+
+  const normalizedModelId = normalize(modelId)
+  const shortId = shortModelId(modelId)
+  return providerMap.get(normalizedModelId) ?? providerMap.get(shortId) ?? null
+}
+
+function resolveProviderAliasModelId(
+  indexes: ModelsDevIndexes,
+  providerKey: string,
+  modelId: string,
+  options?: ModelsDevLookupOptions
+): string | null {
+  const providerRecord = indexes.providerRecords.get(normalize(providerKey))
+  if (!providerRecord || providerRecord.preferredModelIds.length === 0) return null
+
+  const normalizedModelId = normalize(modelId)
+  const shortId = shortModelId(modelId)
+  const sluggedModelId = slugify(modelId)
+  const providerName = String(options?.providerName || '').trim()
+  const normalizedProviderName = providerName ? normalize(providerName) : ''
+  const sluggedProviderName = providerName ? slugify(providerName) : ''
+
+  const matchesProviderAlias = [
+    providerRecord.key,
+    providerRecord.normalizedName || '',
+    providerRecord.nameSlug || '',
+    normalizedProviderName,
+    sluggedProviderName,
+  ].some((candidate) => candidate && (
+    candidate === normalizedModelId ||
+    candidate === shortId ||
+    candidate === sluggedModelId
+  ))
+
+  if (!matchesProviderAlias) return null
+  return providerRecord.preferredModelIds[0] || null
+}
+
+function lookupGlobalIndex<T>(target: Map<string, T>, modelId: string): T | null {
+  const normalizedModelId = normalize(modelId)
+  const shortId = shortModelId(modelId)
+  return target.get(normalizedModelId) ?? target.get(shortId) ?? null
+}
+
+export function lookupModelsDevContextLimitInIndexes(
+  indexes: ModelsDevIndexes,
+  providerType: string,
+  modelId: string,
+  options?: ModelsDevLookupOptions
+): number | null {
+  const candidates = getProviderCandidates(indexes, providerType, modelId, options)
+
+  for (const providerKey of candidates) {
+    const directMatch = lookupInProviderIndex(indexes.providerModelIndex, providerKey, modelId)
+    if (directMatch) return directMatch
+  }
+
+  for (const providerKey of candidates) {
+    const aliasModelId = resolveProviderAliasModelId(indexes, providerKey, modelId, options)
+    if (!aliasModelId) continue
+
+    const aliasMatch = lookupInProviderIndex(indexes.providerModelIndex, providerKey, aliasModelId)
+    if (aliasMatch) return aliasMatch
+  }
+
+  return lookupGlobalIndex(indexes.globalModelIndex, modelId)
+}
+
+export function lookupModelsDevOutputLimitInIndexes(
+  indexes: ModelsDevIndexes,
+  providerType: string,
+  modelId: string,
+  options?: ModelsDevLookupOptions
+): number | null {
+  const candidates = getProviderCandidates(indexes, providerType, modelId, options)
+
+  for (const providerKey of candidates) {
+    const directMatch = lookupInProviderIndex(indexes.providerModelOutputIndex, providerKey, modelId)
+    if (directMatch) return directMatch
+  }
+
+  for (const providerKey of candidates) {
+    const aliasModelId = resolveProviderAliasModelId(indexes, providerKey, modelId, options)
+    if (!aliasModelId) continue
+
+    const aliasMatch = lookupInProviderIndex(indexes.providerModelOutputIndex, providerKey, aliasModelId)
+    if (aliasMatch) return aliasMatch
+  }
+
+  return lookupGlobalIndex(indexes.globalModelOutputIndex, modelId)
+}
+
+export function lookupModelsDevModelMetadataInIndexes(
+  indexes: ModelsDevIndexes,
+  providerType: string,
+  modelId: string,
+  options?: ModelsDevLookupOptions
+): ModelsDevModelMetadata | null {
+  const candidates = getProviderCandidates(indexes, providerType, modelId, options)
+
+  for (const providerKey of candidates) {
+    const directMatch = lookupInProviderMetadataIndex(indexes.providerModelMetadataIndex, providerKey, modelId)
+    if (directMatch) return directMatch
+  }
+
+  for (const providerKey of candidates) {
+    const aliasModelId = resolveProviderAliasModelId(indexes, providerKey, modelId, options)
+    if (!aliasModelId) continue
+
+    const aliasMatch = lookupInProviderMetadataIndex(indexes.providerModelMetadataIndex, providerKey, aliasModelId)
+    if (aliasMatch) return aliasMatch
+  }
+
+  return lookupGlobalIndex(indexes.globalModelMetadataIndex, modelId)
+}

--- a/electron/services/subagents.ts
+++ b/electron/services/subagents.ts
@@ -799,7 +799,10 @@ async function resolveProviderMaxOutputTokens(providerConfig: any, modelId: stri
 
   try {
     await refreshModelCatalog(false)
-    const limit = lookupModelsDevOutputLimit(providerConfig.type, normalizedModel)
+    const limit = lookupModelsDevOutputLimit(providerConfig.type, normalizedModel, {
+      baseUrl: providerConfig.base_url,
+      providerName: providerConfig.name,
+    })
     if (limit && Number.isFinite(limit) && limit > 0) {
       return Math.round(limit)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.35.1",
+      "version": "0.35.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {
@@ -8,7 +8,7 @@
     "dev": "vite",
     "bundle": "npm run sync-icons && tsc && vite build",
     "dev:stable": "npm run bundle && electron .",
-    "test:targeted": "npm run sync-icons && node --test --experimental-strip-types --import ./scripts/register-ts-test-loader.mjs electron/lib/contentSearch.test.ts electron/lib/modeCapabilities.test.ts electron/lib/turnToolSemantics.test.ts electron/services/modelCapabilityProfiles.test.ts src/lib/inlineToolProtocol.test.ts src/stores/chatInterruption.test.ts src/stores/decisionPrompt.test.ts src/stores/updates.test.ts",
+    "test:targeted": "npm run sync-icons && node --test --experimental-strip-types --import ./scripts/register-ts-test-loader.mjs electron/lib/contentSearch.test.ts electron/lib/modeCapabilities.test.ts electron/lib/turnToolSemantics.test.ts electron/services/modelCapabilityProfiles.test.ts electron/services/modelsDevResolver.test.ts src/lib/inlineToolProtocol.test.ts src/stores/chatInterruption.test.ts src/stores/decisionPrompt.test.ts src/stores/updates.test.ts",
     "build": "npm run sync-icons && tsc && vite build && electron-builder",
     "build:x64": "npm run sync-icons && tsc && vite build && electron-builder --x64",
     "build:mac": "npm run sync-icons && tsc && vite build && electron-builder --mac",

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,16 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.35.2',
+    date: '2026-03-09',
+    changes: {
+      fixed: [
+        'Compatible provider lookups now resolve provider-specific Kimi model names such as `kimi-for-coding` through models.dev provider metadata, so Anthropic-compatible Moonshot coding endpoints receive the correct context and output limits instead of falling back to opaque provider defaults (Fixes #141)',
+        'Kimi coding-plan selections now carry the resolved models.dev metadata into runtime capability detection and artifact streaming, reducing truncated HTML artifact failures on large turns (Fixes #141)',
+      ],
+    },
+  },
+  {
     version: '0.35.1',
     date: '2026-03-09',
     changes: {


### PR DESCRIPTION
## Summary
- Compatible Kimi coding endpoints can return provider-specific model names such as `kimi-for-coding`, which caused Jelico to miss models.dev limit metadata and truncate large artifact turns.

## Root Cause
- models.dev lookups depended on direct model-id matches plus generic provider-type candidates.
- Compatible-provider selections persisted the raw `/models` id from the endpoint, so provider-defined names that identified the service instead of the underlying model never resolved to the correct context/output metadata.

## Fix
- Added a pure models.dev resolver that can use provider endpoint metadata, provider names, and provider-key aliases to resolve provider-specific model names to their preferred underlying models.
- Wired that resolver into runtime output-token lookup, compatible context-size lookup, and capability-metadata lookup so the app uses the same resolution path everywhere.

## Changes
- Added `electron/services/modelsDevResolver.ts` and regression coverage for provider-key aliases, base-URL anchoring, and direct-model precedence.
- Refactored `electron/services/modelCatalog.ts` to reuse the pure resolver indexes instead of duplicating lookup logic.
- Updated AI, sub-agent, and provider context lookup paths to pass provider name/base URL into models.dev resolution.
- Updated both changelogs and bumped the app version to `0.35.2`.

## Issue
Fixes #141
