### PR TITLE
Fix light theme contrast and tool call readability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ The Soul/Memory system should make Jelico increasingly personalized - it learns 
 ## Project overview
 Jelico is an AI Productivity Desktop built with Electron, React, TypeScript, and Vite. It provides a frictionless AI assistant experience with multi-provider support (Anthropic, OpenAI, Google), workspace management, conversation persistence, and a soul/memory system that learns user patterns and preferences over time.
 
-**Current Version:** 0.35.1
+**Current Version:** 0.35.3
 
 **License:** GNU General Public License v3.0 (GPL-3.0-or-later)
 - See LICENSE file in project root
@@ -686,7 +686,7 @@ todo_write({ tasks: [
 - **Phase 1-7 Complete**: Core functionality, UI, artifacts, memory, soul system
 - **Phase 8 Complete**: Onboarding flow, backup/restore, versioning
 - **Current Focus**: Testing, polish, user feedback integration, and release hardening across tool UX and workspace flows
-- **Latest Release (0.35.1)**: Patch release focused on interrupted artifact/file workflows, adding provider-side interruption labeling, deterministic recovery for incomplete mutation turns, and safer completion-sensitive streaming/restart handling
+- **Latest Release (0.35.3)**: Patch release focused on light-theme contrast hierarchy, stronger pane/tool readability in bright mode, and clearer processing states during tool execution
 
 ## Code style
 - TypeScript strict mode enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.35.3] - 2026-03-10
+
+### Highlights
+- Light mode now has clearer surface separation across the sidebar, header, chat canvas, and composer so the interface no longer feels washed out.
+- Tool-call cards, status text, and running-action shimmer are easier to read while artifact and file actions are in progress.
+- Update prompts and titlebar/header surfaces now hold their contrast better in light mode, including the area behind the macOS traffic lights.
+
+### Fixed
+- **Light Theme Contrast** — Off-white surfaces in the sidebar, top bar, bottom rail, chat canvas, message bubbles, and update prompts were retuned so panels and actions stay readable without changing the layout.
+- **Tool Call Readability** — Tool action titles, in-progress artifact labels, context meter visibility, and processing gradients now remain legible in light mode, including grouped tool rows and sidebar activity states.
+
+### Changed
+- **Light Theme Palette** — Accent shades and supporting text colors were adjusted to keep the same visual identity while providing stronger contrast on bright backgrounds.
+
 ## [0.35.2] - 2026-03-09
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.35.2",
+      "version": "0.35.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -494,7 +494,7 @@ export default function App() {
       >
         {/* macOS titlebar safe-area fill for the main pane */}
         <div
-          className="absolute top-0 left-0 right-0 bg-bg-surface pointer-events-none"
+          className="pane-surface absolute top-0 left-0 right-0 pointer-events-none"
           style={{ height: 'var(--titlebar-padding)' }}
           aria-hidden="true"
         />
@@ -607,21 +607,21 @@ export default function App() {
                   <button
                     onClick={handleApplyNow}
                     disabled={isUpdateApplying}
-                    className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent text-black hover:bg-accent-bright transition-colors disabled:opacity-50"
+                    className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent text-accent-foreground hover:bg-accent-bright transition-colors disabled:opacity-50"
                   >
                     <RefreshCw className={`w-4 h-4 ${isUpdateApplying ? 'animate-spin' : ''}`} />
                     {isUpdateApplying ? 'Applying...' : 'Apply now'}
                   </button>
                   <button
                     onClick={() => dismissApplyPrompt(downloadedVersion || latestAvailableVersion || null)}
-                    className="px-3 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors"
+                    className="px-3 py-2 rounded-lg border border-border bg-bg-surface text-text-primary hover:bg-bg-hover hover:border-border-strong transition-colors"
                   >
                     Later
                   </button>
                   {updateInfo?.releaseUrl && (
                     <button
                       onClick={handleOpenReleaseNotes}
-                      className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors"
+                      className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-bg-surface text-text-primary hover:bg-bg-hover hover:border-border-strong transition-colors"
                     >
                       <ArrowUpRight className="w-4 h-4" />
                       Release notes
@@ -674,7 +674,7 @@ export default function App() {
                   <button
                     onClick={() => downloadUpdate()}
                     disabled={isUpdateDownloading}
-                    className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent text-black hover:bg-accent-bright transition-colors disabled:opacity-50"
+                    className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent text-accent-foreground hover:bg-accent-bright transition-colors disabled:opacity-50"
                   >
                     <Download className="w-4 h-4" />
                     {isUpdateDownloading ? 'Downloading...' : 'Download update'}
@@ -682,7 +682,7 @@ export default function App() {
                   {updateInfo?.releaseUrl && (
                     <button
                       onClick={handleOpenReleaseNotes}
-                      className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors"
+                      className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-bg-surface text-text-primary hover:bg-bg-hover hover:border-border-strong transition-colors"
                     >
                       <ArrowUpRight className="w-4 h-4" />
                       Release notes
@@ -690,7 +690,7 @@ export default function App() {
                   )}
                   <button
                     onClick={() => dismissAvailablePrompt(latestAvailableVersion)}
-                    className="px-3 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors"
+                    className="px-3 py-2 rounded-lg border border-border bg-bg-surface text-text-primary hover:bg-bg-hover hover:border-border-strong transition-colors"
                   >
                     Later
                   </button>

--- a/src/components/Chat/ChatArea.tsx
+++ b/src/components/Chat/ChatArea.tsx
@@ -528,13 +528,18 @@ export function ChatArea() {
       !notification.conversationId || notification.conversationId === activeConversationId
     )
   }, [systemNotifications, activeConversationId])
+  const chatCanvasStyle = {
+    '--chat-font-scale': chatFontScale,
+    '--app-font-scale': 1,
+    backgroundColor: 'color-mix(in srgb, var(--bg-void) 84%, var(--bg-surface) 16%)',
+  } as Record<string, string | number>
 
   // New chat / Welcome UI - centered stack
   if (showNewChatUI) {
     return (
       <div
         className="flex-1 flex flex-col min-h-0 chat-font-scale"
-        style={{ '--chat-font-scale': chatFontScale, '--app-font-scale': 1 } as Record<string, string | number>}
+        style={chatCanvasStyle}
         data-window-toggle="ignore"
       >
         <div className="flex-1 flex items-center justify-center py-6">
@@ -555,7 +560,7 @@ export function ChatArea() {
   return (
     <div
       className="flex-1 flex flex-col min-h-0 chat-font-scale"
-      style={{ '--chat-font-scale': chatFontScale, '--app-font-scale': 1 } as Record<string, string | number>}
+      style={chatCanvasStyle}
       data-window-toggle="ignore"
     >
       {/* Messages area */}
@@ -586,7 +591,7 @@ export function ChatArea() {
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => resumeInterruptedConversation(activeConversationId || undefined)}
-                    className="px-2 py-1 text-xs font-medium rounded-md bg-accent text-bg-surface hover:opacity-90 transition-opacity"
+                    className="px-2 py-1 text-xs font-medium rounded-md bg-accent text-accent-foreground hover:opacity-90 transition-opacity"
                   >
                     Restart
                   </button>
@@ -650,7 +655,7 @@ export function ChatArea() {
       </div>
 
       {/* Input area */}
-      <div className="border-t border-border bg-bg-surface">
+      <div className="pane-surface border-t border-border">
         <div className={`${footerContainerClass} pt-0 pb-0`}>
           {/* Mode selector rail flush to top separator */}
           <div className="-mx-4 px-4 py-0">
@@ -1273,7 +1278,7 @@ function NewChatView({ disabled, isStreaming }: NewChatViewProps) {
               className={`
                 w-3.5 h-3.5 rounded border transition-colors flex items-center justify-center text-[10px] leading-none
                 ${createWorktreeOnNewChat
-                  ? 'border-accent bg-accent text-bg-deep'
+                  ? 'border-accent bg-accent text-accent-foreground'
                   : 'border-border bg-bg-deep text-transparent'}
                 peer-focus-visible:ring-2 peer-focus-visible:ring-accent/40
               `}

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -778,7 +778,7 @@ export function ChatInput({ disabled, isStreaming, centered }: ChatInputProps) {
               <button
                 onClick={isStreaming ? handleQueueSubmit : handleSubmit}
                 disabled={disabled || !hasDraftToSend}
-                className="relative inline-flex h-[2.2em] w-[2.2em] items-center justify-center rounded-full bg-accent text-black hover:bg-accent-bright disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex-shrink-0"
+                className="relative inline-flex h-[2.2em] w-[2.2em] items-center justify-center rounded-full bg-accent text-accent-foreground hover:bg-accent-bright disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex-shrink-0"
                 title={isStreaming ? 'Queue message' : 'Send message'}
               >
                 <Send className="w-[1.15em] h-[1.15em]" />

--- a/src/components/Chat/DecisionPromptDialog.tsx
+++ b/src/components/Chat/DecisionPromptDialog.tsx
@@ -21,7 +21,7 @@ function getButtonClasses(option: DecisionPromptOption, isDefault: boolean): str
   }
 
   if (option.variant === 'primary' || isDefault) {
-    return 'px-3 py-2 rounded-lg bg-accent text-black hover:bg-accent-bright transition-colors'
+    return 'px-3 py-2 rounded-lg bg-accent text-accent-foreground hover:bg-accent-bright transition-colors'
   }
 
   return 'px-3 py-2 rounded-lg border border-border text-text-secondary hover:text-text-primary hover:border-border-strong transition-colors'

--- a/src/components/Chat/Message.tsx
+++ b/src/components/Chat/Message.tsx
@@ -301,7 +301,7 @@ export function Message({
         </div>
         <div className="max-w-[80%] flex flex-col items-end">
           {/* Message bubble */}
-          <div className="rounded-2xl px-4 py-3 bg-bg-elevated text-text-primary">
+          <div className="rounded-2xl px-4 py-3 bg-bg-hover text-text-primary">
             {/* Show attachments first */}
             {hasAttachments && (
               <div className={`space-y-2 ${hasContent ? 'mb-3' : ''}`}>

--- a/src/components/Chat/MessageActions.tsx
+++ b/src/components/Chat/MessageActions.tsx
@@ -106,7 +106,7 @@ export function MessageActions({ content, segments, toolCalls, toolResults, usag
   }
 
   return (
-    <div className="flex items-center gap-3 mt-3 pt-2 border-t border-border-subtle">
+    <div className="flex items-center gap-3 mt-3 pt-2 border-t border-border">
       {/* Copy button */}
       <button
         onClick={handleCopy}

--- a/src/components/Chat/ToolCallDisplay.tsx
+++ b/src/components/Chat/ToolCallDisplay.tsx
@@ -826,7 +826,7 @@ export function SingleToolCallDisplay({
           <span className="w-4 h-4 flex-shrink-0" />
         )}
 
-        <span className="text-sm font-medium text-accent flex-1 truncate">{label}</span>
+        <span className="text-sm font-medium text-text-primary flex-1 truncate">{label}</span>
 
         {/* Status indicator - for spawn_agent, show sub-agent status instead of tool completion */}
         {toolCall.name === 'spawn_agent' && subAgent ? (
@@ -857,7 +857,7 @@ export function SingleToolCallDisplay({
       {/* Artifact create/update in progress - simple indicator, no streaming preview */}
       {isArtifactMutationTool && !hasResult && (
         <div className="px-3 py-2 border-t border-border bg-bg-surface">
-          <span className="text-xs text-text-muted">
+          <span className="text-xs text-text-primary">
             {isCreateArtifactTool ? 'Creating ' : 'Updating '}
             {formatArtifactType()}...
           </span>
@@ -1143,23 +1143,29 @@ export function ConsolidatedToolCallGroup({
     : errorCount > 0
       ? `${toolCalls.length} calls · ${errorCount} failed`
       : `${toolCalls.length} calls`
+  const processingTone = toolCalls
+    .map((toolCall) => processingToneByToolCallId.get(toolCall.id))
+    .find((tone): tone is number => tone !== undefined) ?? 0
+  const processingToneClass = inProgressCount > 0
+    ? `tool-call-pill-processing tool-call-pill-processing-tone-${processingTone % 4}`
+    : ''
 
   return (
     <div className="border border-border rounded-lg overflow-hidden bg-bg-deep">
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-bg-hover transition-colors"
+        className={`w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-bg-hover transition-colors ${processingToneClass}`}
       >
         {expanded ? (
           <ChevronDown className="w-4 h-4 text-text-muted flex-shrink-0" />
         ) : (
           <ChevronRight className="w-4 h-4 text-text-muted flex-shrink-0" />
         )}
-        <span className="text-sm font-medium text-accent flex-1 truncate">
+        <span className="text-sm font-medium text-text-primary flex-1 truncate">
           {label}
         </span>
-        <span className="text-xs text-text-muted">{statusLabel}</span>
+        <span className="text-xs text-text-secondary">{statusLabel}</span>
         {errorCount > 0 ? (
           <XCircle className="w-4 h-4 text-error flex-shrink-0" />
         ) : inProgressCount === 0 && completedCount > 0 ? (

--- a/src/components/Clarification/ClarificationPanel.tsx
+++ b/src/components/Clarification/ClarificationPanel.tsx
@@ -44,7 +44,7 @@ function OptionRow({
             w-4 h-4 rounded border-2 flex items-center justify-center
             ${isSelected ? 'border-accent bg-accent' : 'border-text-muted'}
           `}>
-            {isSelected && <Check className="w-3 h-3 text-white" />}
+            {isSelected && <Check className="w-3 h-3 text-accent-foreground" />}
           </div>
         ) : (
           <div className={`
@@ -99,7 +99,7 @@ function OtherOption({
               w-4 h-4 rounded border-2 flex items-center justify-center
               ${isSelected ? 'border-accent bg-accent' : 'border-text-muted'}
             `}>
-              {isSelected && <Check className="w-3 h-3 text-white" />}
+              {isSelected && <Check className="w-3 h-3 text-accent-foreground" />}
             </div>
           ) : (
             <div className={`
@@ -384,7 +384,7 @@ export function ClarificationPanel() {
               flex items-center gap-1.5 px-3 py-1 rounded text-sm font-medium
               transition-colors
               ${canSubmit() && !isSubmitting
-                ? 'bg-accent text-white hover:bg-accent-bright'
+                ? 'bg-accent text-accent-foreground hover:bg-accent-bright'
                 : 'bg-bg-elevated text-text-muted cursor-not-allowed'
               }
             `}

--- a/src/components/Conversations/TransferDialog.tsx
+++ b/src/components/Conversations/TransferDialog.tsx
@@ -240,7 +240,7 @@ export function TransferDialog({
                 (selectedWorkspaceId === null && isInSandbox) ||
                 (selectedWorkspaceId === currentWorkspaceId)
               }
-              className="px-4 py-2 text-sm bg-accent text-white rounded-lg hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              className="px-4 py-2 text-sm bg-accent text-accent-foreground rounded-lg hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {isTransferring ? (
                 <>

--- a/src/components/Layout/ContextIndicator.tsx
+++ b/src/components/Layout/ContextIndicator.tsx
@@ -71,11 +71,10 @@ export function ContextIndicator() {
       <button
         onClick={toggleContextText}
         className={`
-          flex items-center gap-[0.45em] px-[0.65em] py-[0.4em] rounded text-xs
-          transition-colors
+          flex items-center gap-[0.45em] px-[0.65em] py-[0.4em] rounded text-xs transition-colors
           ${contextUsage.shouldWarn
             ? 'text-warning hover:bg-warning/10'
-            : 'text-text-muted hover:text-text-secondary hover:bg-bg-surface'}
+            : 'text-text-secondary hover:text-text-primary hover:bg-bg-surface'}
         `}
         title={buttonTitle}
       >
@@ -103,8 +102,8 @@ export function ContextIndicator() {
             strokeWidth={trackStrokeWidth}
             strokeDasharray={trackDashPattern}
             strokeLinecap="round"
-            className="text-text-muted"
-            style={{ opacity: 0.24 }}
+            className="text-border-strong"
+            style={{ opacity: 0.86 }}
           />
           <circle
             cx={circleSize / 2}
@@ -123,7 +122,7 @@ export function ContextIndicator() {
 
       {/* Percentage text - toggles on circle click */}
       {showContextText && (
-        <span className="text-sm text-text-secondary">
+        <span className="text-sm text-text-primary">
           Context: {percentage}%{compactText}
         </span>
       )}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -24,7 +24,7 @@ export function Header() {
 
   return (
     <header
-      className="flex items-center justify-between px-4 border-b border-border bg-bg-surface"
+      className="pane-surface flex items-center justify-between px-4 border-b border-border"
       style={{ height: 'clamp(2.9rem, calc(3.5rem * var(--app-font-scale, 1)), 4.4rem)' }}
     >
       {/* Left - Workspace selector, Model, Context */}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -370,7 +370,7 @@ export function Sidebar() {
 
   return (
     <div
-      className="w-64 bg-bg-surface border-r border-border flex flex-col"
+      className="pane-surface w-64 border-r border-border flex flex-col"
       style={{ paddingTop: 'var(--titlebar-padding)' }}
     >
       {/* Header */}
@@ -453,7 +453,7 @@ export function Sidebar() {
               </div>
 
               {isExpanded && (
-                <div className="ml-5 mt-1 border-l border-border/50 pl-2">
+                <div className="ml-5 mt-1 border-l border-border-strong pl-2">
                   {group.conversations.map((conv) => {
                     const convArtifacts = getArtifactsForConversation(conv.id)
                     const hasArtifacts = convArtifacts.length > 0
@@ -523,7 +523,7 @@ export function Sidebar() {
                         </div>
 
                         {hasExpandableContent && isConversationExpanded && (
-                          <div className="ml-6 pl-2 border-l border-border/40 mt-1 mb-2">
+                          <div className="ml-6 pl-2 border-l border-border-strong mt-1 mb-2">
                             {hasArtifacts && (
                               <div className="text-[10px] text-text-faint uppercase tracking-wider mb-1">Artifacts</div>
                             )}

--- a/src/components/Onboarding/WelcomeScreen.tsx
+++ b/src/components/Onboarding/WelcomeScreen.tsx
@@ -110,7 +110,7 @@ export function WelcomeScreen({ onComplete }: WelcomeScreenProps) {
               <button
                 onClick={handleNext}
                 disabled={!canContinue()}
-                className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-black font-medium rounded-lg hover:bg-accent-bright transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-accent-foreground font-medium rounded-lg hover:bg-accent-bright transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Continue
                 <ArrowRight className="w-4 h-4" />
@@ -165,7 +165,7 @@ export function WelcomeScreen({ onComplete }: WelcomeScreenProps) {
               </button>
               <button
                 onClick={handleNext}
-                className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-black font-medium rounded-lg hover:bg-accent-bright transition-colors"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-accent-foreground font-medium rounded-lg hover:bg-accent-bright transition-colors"
               >
                 {profile.intentions.trim() ? 'Continue' : 'Skip for now'}
                 <ArrowRight className="w-4 h-4" />
@@ -220,7 +220,7 @@ export function WelcomeScreen({ onComplete }: WelcomeScreenProps) {
               </button>
               <button
                 onClick={handleNext}
-                className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-black font-medium rounded-lg hover:bg-accent-bright transition-colors"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-accent-foreground font-medium rounded-lg hover:bg-accent-bright transition-colors"
               >
                 {profile.preferences.trim() ? 'Continue' : 'Skip for now'}
                 <ArrowRight className="w-4 h-4" />
@@ -275,7 +275,7 @@ export function WelcomeScreen({ onComplete }: WelcomeScreenProps) {
               </button>
               <button
                 onClick={handleNext}
-                className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-black font-medium rounded-lg hover:bg-accent-bright transition-colors"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-accent-foreground font-medium rounded-lg hover:bg-accent-bright transition-colors"
               >
                 {profile.additionalInfo.trim() ? 'Continue' : 'Skip for now'}
                 <ArrowRight className="w-4 h-4" />
@@ -336,7 +336,7 @@ export function WelcomeScreen({ onComplete }: WelcomeScreenProps) {
           </button>
           <button
             onClick={handleNext}
-            className="inline-flex items-center gap-2 px-8 py-3 bg-accent text-black font-medium rounded-lg hover:bg-accent-bright transition-colors"
+            className="inline-flex items-center gap-2 px-8 py-3 bg-accent text-accent-foreground font-medium rounded-lg hover:bg-accent-bright transition-colors"
           >
             Let's Begin
             <ArrowRight className="w-4 h-4" />

--- a/src/components/Settings/BackupSettings.tsx
+++ b/src/components/Settings/BackupSettings.tsx
@@ -243,7 +243,7 @@ export function BackupSettings() {
         <button
           onClick={handleExport}
           disabled={exporting}
-          className="flex items-center gap-2 px-4 py-2 text-sm bg-accent text-black rounded-lg hover:bg-accent-bright transition-colors disabled:opacity-50"
+          className="flex items-center gap-2 px-4 py-2 text-sm bg-accent text-accent-foreground rounded-lg hover:bg-accent-bright transition-colors disabled:opacity-50"
         >
           {exporting ? (
             <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -271,7 +271,7 @@ export function GeneralSettings() {
                 <button
                   onClick={() => downloadUpdate()}
                   disabled={isDownloading}
-                  className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent text-black hover:bg-accent-bright transition-colors disabled:opacity-50"
+                  className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent text-accent-foreground hover:bg-accent-bright transition-colors disabled:opacity-50"
                 >
                   <Download className="w-4 h-4" />
                   {isDownloading ? 'Downloading...' : 'Download update'}
@@ -314,7 +314,7 @@ export function GeneralSettings() {
                   <div className="flex flex-wrap gap-2">
                     <button
                       onClick={() => applyDownloadedUpdate()}
-                      className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent text-black hover:bg-accent-bright transition-colors"
+                      className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent text-accent-foreground hover:bg-accent-bright transition-colors"
                     >
                       <Download className="w-4 h-4" />
                       Apply now

--- a/src/components/Settings/MicrophoneSettings.tsx
+++ b/src/components/Settings/MicrophoneSettings.tsx
@@ -515,7 +515,7 @@ export function MicrophoneSettings() {
                         handleDownloadModel(model.id)
                       }}
                       disabled={isDownloading}
-                      className="flex items-center gap-1 px-3 py-1.5 bg-accent text-black rounded-lg hover:bg-accent-bright transition-colors text-sm disabled:opacity-50"
+                      className="flex items-center gap-1 px-3 py-1.5 bg-accent text-accent-foreground rounded-lg hover:bg-accent-bright transition-colors text-sm disabled:opacity-50"
                     >
                       <Download className="w-4 h-4" />
                       Download
@@ -545,7 +545,7 @@ export function MicrophoneSettings() {
             <button
               onClick={handleTestTranscription}
               disabled={isTranscribing || isDownloading}
-              className="flex items-center gap-2 px-4 py-2 bg-accent text-black rounded-lg hover:bg-accent-bright transition-colors disabled:opacity-50"
+              className="flex items-center gap-2 px-4 py-2 bg-accent text-accent-foreground rounded-lg hover:bg-accent-bright transition-colors disabled:opacity-50"
             >
               {isTranscribing ? (
                 <>

--- a/src/components/Settings/ProfileSettings.tsx
+++ b/src/components/Settings/ProfileSettings.tsx
@@ -119,7 +119,7 @@ export function ProfileSettings() {
             <button
               onClick={handleSaveProfile}
               disabled={isSavingProfile}
-              className="flex items-center gap-2 px-4 py-2 bg-accent text-black rounded-lg hover:bg-accent-bright transition-colors disabled:opacity-50"
+              className="flex items-center gap-2 px-4 py-2 bg-accent text-accent-foreground rounded-lg hover:bg-accent-bright transition-colors disabled:opacity-50"
             >
               {profileSaved ? (
                 <>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -492,7 +492,7 @@ export function Settings({ onClose }: SettingsProps) {
                     onClose()
                     openProviderSetup()
                   }}
-                  className="flex items-center gap-2 px-3 py-1.5 text-sm bg-accent text-black rounded-lg hover:bg-accent-bright transition-colors"
+                  className="flex items-center gap-2 px-3 py-1.5 text-sm bg-accent text-accent-foreground rounded-lg hover:bg-accent-bright transition-colors"
                 >
                   <Plus className="w-4 h-4" />
                   Add Provider
@@ -790,7 +790,7 @@ export function Settings({ onClose }: SettingsProps) {
                           <div className="flex items-center gap-2 mt-3">
                             <button
                               onClick={saveProviderEdit}
-                              className="px-3 py-1.5 text-sm bg-accent text-black rounded hover:bg-accent-bright transition-colors"
+                              className="px-3 py-1.5 text-sm bg-accent text-accent-foreground rounded hover:bg-accent-bright transition-colors"
                             >
                               Save
                             </button>

--- a/src/components/Skills/SkillManager.tsx
+++ b/src/components/Skills/SkillManager.tsx
@@ -27,7 +27,7 @@ export function SkillManager() {
         <h3 className="text-lg font-medium text-text-primary">Skills</h3>
         <button
           onClick={() => setIsCreating(true)}
-          className="flex items-center gap-2 px-3 py-1.5 text-sm bg-accent text-black rounded-lg hover:bg-accent-bright transition-colors"
+          className="flex items-center gap-2 px-3 py-1.5 text-sm bg-accent text-accent-foreground rounded-lg hover:bg-accent-bright transition-colors"
         >
           <Plus className="w-4 h-4" />
           New Skill
@@ -258,7 +258,7 @@ function SkillEditor({
             </button>
             <button
               type="submit"
-              className="px-4 py-2 text-sm bg-accent text-black rounded-lg hover:bg-accent-bright"
+              className="px-4 py-2 text-sm bg-accent text-accent-foreground rounded-lg hover:bg-accent-bright"
             >
               Save Skill
             </button>

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,19 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.35.3',
+    date: '2026-03-10',
+    changes: {
+      fixed: [
+        'Light theme surfaces now use a clearer off-white contrast ladder across the header, sidebar, composer rail, chat canvas, update prompts, and message bubbles so light mode no longer washes out UI structure or accent details (Fixes #140)',
+        'Tool-call headers, in-progress artifact copy, context meter ring, and light-mode processing shimmer states now remain legible while actions are running, including grouped tool-call rows and sidebar processing gradients (Fixes #140)',
+      ],
+      changed: [
+        'Light theme accent variants and accent-foreground tokens were rebalanced to preserve the existing palette while improving button and action contrast on brighter surfaces',
+      ],
+    },
+  },
+  {
     version: '0.35.2',
     date: '2026-03-09',
     changes: {

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -48,16 +48,16 @@ export const COLOR_THEMES: ColorTheme[] = [
       bgActive: '#2a2a32',
     },
     light: {
-      accent: '#b8860b',
-      accentBright: '#daa520',
-      accentDim: '#8b6914',
-      accentGlow: 'rgba(184, 134, 11, 0.15)',
-      bgVoid: '#f5f5f5',
-      bgDeep: '#ebebeb',
-      bgSurface: '#ffffff',
-      bgElevated: '#fafafa',
-      bgHover: '#f0f0f0',
-      bgActive: '#e5e5e5',
+      accent: '#9f740f',
+      accentBright: '#b58411',
+      accentDim: '#7d5a0c',
+      accentGlow: 'rgba(159, 116, 15, 0.18)',
+      bgVoid: '#f7f2ea',
+      bgDeep: '#d7cab7',
+      bgSurface: '#e7dccb',
+      bgElevated: '#f3ede2',
+      bgHover: '#ddd1be',
+      bgActive: '#cfbfaa',
     },
   },
   {
@@ -76,16 +76,16 @@ export const COLOR_THEMES: ColorTheme[] = [
       bgActive: '#2a3344',
     },
     light: {
-      accent: '#2563eb',
-      accentBright: '#3b82f6',
-      accentDim: '#1d4ed8',
-      accentGlow: 'rgba(37, 99, 235, 0.15)',
-      bgVoid: '#f0f4f8',
-      bgDeep: '#e8eef4',
-      bgSurface: '#ffffff',
-      bgElevated: '#f8fafc',
-      bgHover: '#f1f5f9',
-      bgActive: '#e2e8f0',
+      accent: '#1d4ed8',
+      accentBright: '#2563eb',
+      accentDim: '#1e40af',
+      accentGlow: 'rgba(29, 78, 216, 0.18)',
+      bgVoid: '#f6f9fc',
+      bgDeep: '#cfdce8',
+      bgSurface: '#dfe8f2',
+      bgElevated: '#eef4fa',
+      bgHover: '#d4e0eb',
+      bgActive: '#c5d3e2',
     },
   },
   {
@@ -104,16 +104,16 @@ export const COLOR_THEMES: ColorTheme[] = [
       bgActive: '#2a332a',
     },
     light: {
-      accent: '#059669',
-      accentBright: '#10b981',
-      accentDim: '#047857',
-      accentGlow: 'rgba(5, 150, 105, 0.15)',
-      bgVoid: '#f0f5f0',
-      bgDeep: '#e8f0e8',
-      bgSurface: '#ffffff',
-      bgElevated: '#f8faf8',
-      bgHover: '#f0f5f0',
-      bgActive: '#e0ebe0',
+      accent: '#047857',
+      accentBright: '#059669',
+      accentDim: '#065f46',
+      accentGlow: 'rgba(4, 120, 87, 0.18)',
+      bgVoid: '#f5f8f4',
+      bgDeep: '#cfdccf',
+      bgSurface: '#dde8dc',
+      bgElevated: '#eef4ed',
+      bgHover: '#d3dfd2',
+      bgActive: '#c4d3c3',
     },
   },
   {
@@ -132,16 +132,16 @@ export const COLOR_THEMES: ColorTheme[] = [
       bgActive: '#332a4a',
     },
     light: {
-      accent: '#7c3aed',
-      accentBright: '#8b5cf6',
-      accentDim: '#6d28d9',
-      accentGlow: 'rgba(124, 58, 237, 0.15)',
-      bgVoid: '#f5f0fa',
-      bgDeep: '#ede8f4',
-      bgSurface: '#ffffff',
-      bgElevated: '#faf8fc',
-      bgHover: '#f3f0f8',
-      bgActive: '#e8e0f0',
+      accent: '#6d28d9',
+      accentBright: '#7c3aed',
+      accentDim: '#5b21b6',
+      accentGlow: 'rgba(109, 40, 217, 0.18)',
+      bgVoid: '#f7f4fb',
+      bgDeep: '#d6cee8',
+      bgSurface: '#e6def1',
+      bgElevated: '#f1ecf8',
+      bgHover: '#dbd2eb',
+      bgActive: '#cdc2df',
     },
   },
   {
@@ -160,16 +160,16 @@ export const COLOR_THEMES: ColorTheme[] = [
       bgActive: '#442a38',
     },
     light: {
-      accent: '#db2777',
-      accentBright: '#ec4899',
-      accentDim: '#be185d',
-      accentGlow: 'rgba(219, 39, 119, 0.15)',
-      bgVoid: '#fdf2f8',
-      bgDeep: '#fce7f3',
-      bgSurface: '#ffffff',
-      bgElevated: '#fefafc',
-      bgHover: '#fdf4f8',
-      bgActive: '#fce8f0',
+      accent: '#be185d',
+      accentBright: '#db2777',
+      accentDim: '#9d174d',
+      accentGlow: 'rgba(190, 24, 93, 0.18)',
+      bgVoid: '#fcf4f7',
+      bgDeep: '#e7d1da',
+      bgSurface: '#f0dde6',
+      bgElevated: '#f7edf2',
+      bgHover: '#e8d4de',
+      bgActive: '#dac3cd',
     },
   },
 ]
@@ -238,6 +238,7 @@ export const useThemeStore = create<ThemeStore>((set, get) => ({
     root.style.setProperty('--accent-bright', colors.accentBright)
     root.style.setProperty('--accent-dim', colors.accentDim)
     root.style.setProperty('--accent-glow', colors.accentGlow)
+    root.style.setProperty('--accent-foreground', effectiveMode === 'light' ? '#fffdf8' : '#0d0d10')
 
     // Apply background colors
     root.style.setProperty('--bg-void', colors.bgVoid)
@@ -249,13 +250,13 @@ export const useThemeStore = create<ThemeStore>((set, get) => ({
 
     // Update text and border colors based on mode
     if (effectiveMode === 'light') {
-      root.style.setProperty('--text-primary', '#1a1a1a')
-      root.style.setProperty('--text-secondary', '#4a4a4a')
-      root.style.setProperty('--text-muted', '#6a6a6a')
-      root.style.setProperty('--text-faint', '#9a9a9a')
-      root.style.setProperty('--border', '#e0e0e0')
-      root.style.setProperty('--border-subtle', '#f0f0f0')
-      root.style.setProperty('--border-strong', '#d0d0d0')
+      root.style.setProperty('--text-primary', '#191612')
+      root.style.setProperty('--text-secondary', '#4e473f')
+      root.style.setProperty('--text-muted', '#70675c')
+      root.style.setProperty('--text-faint', '#9b9186')
+      root.style.setProperty('--border', '#c8b79f')
+      root.style.setProperty('--border-subtle', '#d9cab7')
+      root.style.setProperty('--border-strong', '#9f896d')
       root.classList.remove('dark')
       root.classList.add('light')
     } else {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,6 +25,7 @@
     --accent-bright: #e8c49a;
     --accent-dim: #b8863d;
     --accent-glow: rgba(212, 165, 116, 0.15);
+    --accent-foreground: #0d0d10;
 
     /* Status colors */
     --success: #5cb97b;
@@ -54,21 +55,27 @@
 
   /* Light mode overrides */
   :root.light {
-    --bg-void: #f5f5f5;
-    --bg-deep: #ebebeb;
-    --bg-surface: #ffffff;
-    --bg-elevated: #fafafa;
-    --bg-hover: #f0f0f0;
-    --bg-active: #e5e5e5;
+    --accent: #9f740f;
+    --accent-bright: #b58411;
+    --accent-dim: #7d5a0c;
+    --accent-glow: rgba(159, 116, 15, 0.18);
+    --accent-foreground: #fffdf8;
 
-    --text-primary: #1a1a1a;
-    --text-secondary: #4a4a4a;
-    --text-muted: #6a6a6a;
-    --text-faint: #9a9a9a;
+    --bg-void: #f7f2ea;
+    --bg-deep: #d7cab7;
+    --bg-surface: #e7dccb;
+    --bg-elevated: #f3ede2;
+    --bg-hover: #ddd1be;
+    --bg-active: #cfbfaa;
 
-    --border: #e0e0e0;
-    --border-subtle: #f0f0f0;
-    --border-strong: #d0d0d0;
+    --text-primary: #191612;
+    --text-secondary: #4e473f;
+    --text-muted: #70675c;
+    --text-faint: #9b9186;
+
+    --border: #c8b79f;
+    --border-subtle: #d9cab7;
+    --border-strong: #9f896d;
   }
 
   :root.os-mac {
@@ -437,6 +444,71 @@
   );
 }
 
+:root.light .sidebar-conversation-processing {
+  background-image: linear-gradient(
+    135deg,
+    transparent 0%,
+    color-mix(in srgb, var(--accent-dim) 8%, transparent) 22%,
+    color-mix(in srgb, var(--accent-dim) 18%, transparent) 42%,
+    color-mix(in srgb, var(--accent) 28%, transparent) 50%,
+    color-mix(in srgb, var(--accent-dim) 18%, transparent) 58%,
+    color-mix(in srgb, var(--accent-dim) 8%, transparent) 78%,
+    transparent 100%
+  );
+}
+
+:root.light .tool-call-pill-processing-tone-0 {
+  background-image: linear-gradient(
+    135deg,
+    transparent 0%,
+    color-mix(in srgb, var(--accent) 10%, transparent) 22%,
+    color-mix(in srgb, var(--accent) 19%, transparent) 42%,
+    color-mix(in srgb, var(--accent) 30%, transparent) 50%,
+    color-mix(in srgb, var(--accent) 19%, transparent) 58%,
+    color-mix(in srgb, var(--accent) 10%, transparent) 78%,
+    transparent 100%
+  );
+}
+
+:root.light .tool-call-pill-processing-tone-1 {
+  background-image: linear-gradient(
+    135deg,
+    transparent 0%,
+    color-mix(in srgb, var(--accent-bright) 10%, transparent) 22%,
+    color-mix(in srgb, var(--accent-bright) 20%, transparent) 42%,
+    color-mix(in srgb, var(--accent-bright) 31%, transparent) 50%,
+    color-mix(in srgb, var(--accent-bright) 20%, transparent) 58%,
+    color-mix(in srgb, var(--accent-bright) 10%, transparent) 78%,
+    transparent 100%
+  );
+}
+
+:root.light .tool-call-pill-processing-tone-2 {
+  background-image: linear-gradient(
+    135deg,
+    transparent 0%,
+    color-mix(in srgb, var(--accent-dim) 10%, transparent) 22%,
+    color-mix(in srgb, var(--accent-dim) 21%, transparent) 42%,
+    color-mix(in srgb, var(--accent-dim) 32%, transparent) 50%,
+    color-mix(in srgb, var(--accent-dim) 21%, transparent) 58%,
+    color-mix(in srgb, var(--accent-dim) 10%, transparent) 78%,
+    transparent 100%
+  );
+}
+
+:root.light .tool-call-pill-processing-tone-3 {
+  background-image: linear-gradient(
+    135deg,
+    transparent 0%,
+    color-mix(in srgb, var(--accent-bright) 9%, transparent) 22%,
+    color-mix(in srgb, color-mix(in srgb, var(--accent-bright) 65%, var(--accent) 35%) 19%, transparent) 42%,
+    color-mix(in srgb, color-mix(in srgb, var(--accent-bright) 65%, var(--accent) 35%) 30%, transparent) 50%,
+    color-mix(in srgb, color-mix(in srgb, var(--accent-bright) 65%, var(--accent) 35%) 19%, transparent) 58%,
+    color-mix(in srgb, var(--accent-bright) 9%, transparent) 78%,
+    transparent 100%
+  );
+}
+
 @media (prefers-reduced-motion: reduce) {
   .tool-call-pill-processing {
     animation: none;
@@ -504,6 +576,10 @@
   .btn-ghost:hover {
     color: var(--text-primary);
     background: var(--bg-hover);
+  }
+
+  .pane-surface {
+    background-color: color-mix(in srgb, var(--bg-surface) 84%, var(--bg-elevated) 16%);
   }
 
   .input {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -32,6 +32,7 @@ module.exports = {
           bright: 'var(--accent-bright)',
           dim: 'var(--accent-dim)',
           glow: 'var(--accent-glow)',
+          foreground: 'var(--accent-foreground)',
         },
         success: 'var(--success)',
         error: 'var(--error)',


### PR DESCRIPTION
## Summary
- Light theme surfaces and action states were too washed out, making panes, chat bubbles, update prompts, and tool-call progress hard to read in bright mode.

## Root Cause
- The light palette used near-white surfaces and low-contrast accent and text combinations, and tool-call processing states reused tones that were too faint against the light shell.

## Fix
- Rebalanced light-mode surface and accent tokens, applied clearer pane-specific shell surfaces, and darkened tool-call labels and processing shimmer states while preserving the existing layout.

## Changes
- Tuned light-mode theme tokens and CSS defaults for surfaces, borders, and accent foregrounds.
- Refined header, sidebar, composer, update-banner, chat canvas, user bubble, context ring, and tool-call readability in light mode.
- Bumped release metadata to 0.35.3 in package files, changelogs, and AGENTS.md.

## Issue
Fixes #140