### PR TITLE
Fix compatible-provider max token fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -685,10 +685,11 @@ todo_write({ tasks: [
 
 - **Phase 1-7 Complete**: Core functionality, UI, artifacts, memory, soul system
 - **Phase 8 Complete**: Onboarding flow, backup/restore, versioning
-- **Current Focus**: Testing, polish, user feedback integration, release hardening across updater/restart UX, and broader provider setup/model-selection workflows for multi-provider reasoning, conversation-scoped overrides, and metadata visibility.
-- **Next Planned Release (0.38.0)**: Minor release planned from the current PR branch to add API-driven provider setup/editing, supported reasoning-effort defaults and overrides, expanded hosted/local provider presets, drag-reorderable provider metadata rows in Settings, and follow-up reliability fixes for prefixed reasoning-model IDs, per-conversation reasoning routing, provider-default inheritance on `Default` reasoning chats, and provider-selection stability during restore/delete flows.
-- **Latest Public Release (0.37.2)**: Patch release focused on restoring light-mode visibility for the new-chat animated backdrop and the sidebar's color-coded conversation status sections.
+- **Current Focus**: Testing, polish, user feedback integration, release hardening across updater/restart UX, broader provider setup/model-selection workflows for multi-provider reasoning, conversation-scoped overrides, and metadata visibility, plus compatible-provider request-shape hardening so generic OpenAI/Anthropic-compatible backends do not inherit unsupported payload caps from unrelated models.dev entries.
+- **Next Planned Release (0.38.1)**: Patch release planned on top of `0.38.0` to keep generic compatible providers from sending unsupported streamed chat payload caps while preserving provider-specific models.dev matches for known endpoints such as MiniMax coding-plan models.
+- **Latest Public Release (0.38.0)**: Minor release focused on expanded provider setup presets, live model discovery, inline provider metadata visibility, provider-level reasoning defaults, and conversation-scoped reasoning overrides.
 - **Public Release History**:
+  - `0.38.0` - Expanded provider setup presets, live model discovery, drag-reorderable provider metadata, and provider/conversation reasoning controls.
   - `0.37.2` - Restored light-mode visibility for the animated new-chat backdrop and sidebar conversation status tinting.
   - `0.37.1` - Safer updater apply/restart flows across custom macOS install targets, legacy installer preservation, and light-theme context-indicator readability.
   - `0.37.0` - Animated new-chat backdrop, grouped sidebar conversation statuses, inline archive confirmation/toasts, and macOS-native docking behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.38.1] - 2026-03-14
+
+### Highlights
+- Generic compatible providers no longer borrow a different vendor's large output-token cap just because the model name matches a models.dev entry.
+- Streamed chat turns on providers like Nous Research now avoid the unsupported request shape that caused simple prompts to fail before any response text appeared.
+
+### Fixed
+- **Compatible Provider Output Caps** — Jelico now skips foreign models.dev output-limit guesses for generic compatible providers unless the provider itself matches by name or endpoint, so unsupported `max_tokens` values are no longer injected into normal streamed chats.
+
 ## [0.38.0] - 2026-03-13
 
 ### Highlights

--- a/electron/services/modelsDevResolver.test.ts
+++ b/electron/services/modelsDevResolver.test.ts
@@ -39,6 +39,25 @@ const indexes = buildModelsDevIndexes({
       },
     },
   },
+  nebius: {
+    id: 'nebius',
+    name: 'Nebius',
+    api: 'https://api.studio.nebius.com/v1',
+    models: {
+      'NousResearch/Hermes-4-405B': {
+        id: 'NousResearch/Hermes-4-405B',
+        name: 'Hermes 4 405B',
+        reasoning: true,
+        tool_call: true,
+        release_date: '2026-03',
+        last_updated: '2026-03',
+        limit: {
+          context: 262144,
+          output: 131072,
+        },
+      },
+    },
+  },
 })
 
 test('provider-specific model ids can resolve to preferred provider models', () => {
@@ -94,5 +113,29 @@ test('compatible provider base URLs can anchor provider-specific names to models
       providerName: 'Kimi For Coding',
     }),
     32768
+  )
+})
+
+test('generic compatible providers do not inherit foreign global output limits without a provider match', () => {
+  const options = {
+    baseUrl: 'https://inference-api.nousresearch.com/v1',
+    providerName: 'Nous Research',
+  }
+
+  assert.equal(
+    lookupModelsDevOutputLimitInIndexes(indexes, 'openai-compatible', 'Hermes-4-405B', options),
+    null
+  )
+
+  const metadata = lookupModelsDevModelMetadataInIndexes(
+    indexes,
+    'openai-compatible',
+    'Hermes-4-405B',
+    options
+  )
+  assert.equal(metadata?.providerKey, 'nebius')
+  assert.equal(
+    lookupModelsDevContextLimitInIndexes(indexes, 'openai-compatible', 'Hermes-4-405B', options),
+    262144
   )
 })

--- a/electron/services/modelsDevResolver.ts
+++ b/electron/services/modelsDevResolver.ts
@@ -419,6 +419,21 @@ function lookupGlobalIndex<T>(target: Map<string, T>, modelId: string): T | null
   return target.get(normalizedModelId) ?? target.get(shortId) ?? null
 }
 
+function shouldAllowGlobalOutputLimitFallback(
+  providerType: string,
+): boolean {
+  const normalizedType = normalize(providerType)
+  switch (normalizedType) {
+    case 'openai-compatible':
+    case 'anthropic-compatible':
+    case 'custom':
+    case 'local':
+      return false
+    default:
+      return true
+  }
+}
+
 export function lookupModelsDevContextLimitInIndexes(
   indexes: ModelsDevIndexes,
   providerType: string,
@@ -462,6 +477,10 @@ export function lookupModelsDevOutputLimitInIndexes(
 
     const aliasMatch = lookupInProviderIndex(indexes.providerModelOutputIndex, providerKey, aliasModelId)
     if (aliasMatch) return aliasMatch
+  }
+
+  if (!shouldAllowGlobalOutputLimitFallback(providerType)) {
+    return null
   }
 
   return lookupGlobalIndex(indexes.globalModelOutputIndex, modelId)

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.38.1',
+    date: '2026-03-14',
+    changes: {
+      fixed: [
+        'Generic compatible providers no longer inherit foreign models.dev output-token limits by model name alone, so streamed chat turns avoid sending unsupported `max_tokens` caps to backends like Nous Research while still preserving provider-specific matches such as MiniMax coding-plan models (Fixes #171)',
+      ],
+    },
+  },
+  {
     version: '0.38.0',
     date: '2026-03-13',
     changes: {


### PR DESCRIPTION
## Summary
- Generic compatible providers could fail simple streamed chat turns because Jelico injected an unsupported max_tokens cap inferred from an unrelated models.dev provider record.

## Root Cause
- lookupModelsDevOutputLimit allowed global model-name fallback for generic compatible providers, so Hermes-4-405B on the Nous endpoint inherited a 131072 output cap from a foreign catalog entry.
- The streamed chat path then serialized that cap into the live request, and the provider rejected the payload with 400 Bad Request.

## Fix
- Stop applying foreign global output-limit fallback for generic openai-compatible, nthropic-compatible, custom, and local providers unless there is a provider-specific match.
- Preserve provider-specific matches such as MiniMax coding-plan models, and add a regression test covering the Nous-style mismatch.

## Changes
- Narrowed models.dev output-limit fallback behavior in the resolver.
- Added regression coverage for generic compatible providers with foreign model-name matches.
- Updated AGENTS.md, the technical changelog, and the user-facing changelog for the planned patch release.

## Issue
Fixes #171