### PR TITLE
v0.40.0: Context menus, conversation logs, Full Execute toggle, tool capability badges

### DIFF
--- a/electron/ipc/ai.ts
+++ b/electron/ipc/ai.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
 import { providerDb, conversationDb, messageDb, workspaceDb, artifactDb } from '../services/database'
 import { keychainService } from '../services/keychain'
 import { buildSystemPrompt, buildLeanSystemPrompt, type AgentMode, getCachedPrompt } from '../lib/modes'
-import { getModeCapabilities, canSubAgentMutate, assertCapabilityMatrix } from '../lib/modeCapabilities'
+import { getEffectiveModeCapabilities, canSubAgentMutate, assertCapabilityMatrix } from '../lib/modeCapabilities'
 import { searchFileContents } from '../lib/contentSearch'
 import { buildMemoryContext, formatSoulForContext } from '../services/soul'
 import { listSkills } from '../services/skills'
@@ -83,6 +83,7 @@ startOrphanCleanup()
 const activeStreams = new Map<string, AbortController>()
 // Track effective mode per active stream so runtime mode changes can affect tool policy.
 const streamRuntimeModes = new Map<string, AgentMode>()
+const streamRuntimeFullExecute = new Map<string, boolean>()
 
 // Track pending clarification requests (requestId -> resolver)
 interface PendingClarification {
@@ -1299,6 +1300,7 @@ function getBuiltInTools(
     expectedArtifactMutation?: boolean
     allowAllSession?: boolean
     getRuntimeMode?: () => AgentMode
+    getRuntimeFullExecute?: () => boolean
     resetActivityTimeout?: () => void  // Allows blocking tools to keep stream alive
     spawnedAgentIds: Set<string>  // Track spawned agent IDs for orphan detection
     awaitedAgentIds: Set<string>  // Track awaited agent IDs for orphan detection
@@ -1313,10 +1315,13 @@ function getBuiltInTools(
 ) {
   assertCapabilityMatrix()
   const getRuntimeMode = () => streamContext.getRuntimeMode?.() ?? mode
-  const modeCapabilities = getModeCapabilities(mode)
+  const modeCapabilities = getEffectiveModeCapabilities({
+    mode: getRuntimeMode(),
+    fullExecuteEnabled: streamContext.getRuntimeFullExecute?.() ?? mode === 'execute',
+  })
   const canWrite = modeCapabilities.main.canWriteFiles
   const canExecute = modeCapabilities.main.canExecuteCommands
-  const shouldBypassPermissionsForMode = () => getRuntimeMode() === 'execute'
+  const shouldBypassPermissionsForMode = () => streamContext.getRuntimeFullExecute?.() === true || getRuntimeMode() === 'execute'
   // Web research is delegated through sub-agents in all modes.
   const canSpawnAgents = true
   // Main AI keeps direct web tools as an internal fallback after helper-agent research.
@@ -3909,8 +3914,10 @@ export function registerAIHandlers() {
 
       // Create provider instance
       const provider = getProviderInstance(providerConfig, apiKey || '')
-      const mode: AgentMode = params.mode || 'auto'
+      const mode: AgentMode = params.mode === 'execute' ? 'auto' : (params.mode || 'auto')
+      const fullExecuteEnabled = params.fullExecuteEnabled === true
       streamRuntimeModes.set(channelId, mode)
+      streamRuntimeFullExecute.set(channelId, fullExecuteEnabled)
       const latestUserText = getLatestUserMessageText(params.messages)
       const conversationRecord = params.conversationId ? conversationDb.get(params.conversationId) : null
       const workspaceIdForLearning = conversationRecord?.workspace_id || undefined
@@ -4123,6 +4130,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
         expectedArtifactMutation,
         allowAllSession,
         getRuntimeMode: () => streamRuntimeModes.get(channelId) || mode,
+        getRuntimeFullExecute: () => streamRuntimeFullExecute.get(channelId) === true,
         resetActivityTimeout, // Allow blocking tools like wait_for_agent to keep stream alive
         spawnedAgentIds: new Set<string>(),  // Track spawned agent IDs for orphan detection
         awaitedAgentIds: new Set<string>(),  // Track awaited agent IDs for orphan detection
@@ -5118,6 +5126,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
       clearTimeout(maxTimeoutId)
       activeStreams.delete(channelId)
       streamRuntimeModes.delete(channelId)
+      streamRuntimeFullExecute.delete(channelId)
 
       // Safety: ensure no background sub-agents keep running after parent stream ends.
       // Keep callback active until after cancel so renderer receives terminal status updates.
@@ -5145,7 +5154,13 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
     if (!channelId || typeof channelId !== 'string') return
     if (!mode || typeof mode !== 'string') return
     if (!activeStreams.has(channelId)) return
-    streamRuntimeModes.set(channelId, mode)
+    streamRuntimeModes.set(channelId, mode === 'execute' ? 'auto' : mode)
+  })
+
+  ipcMain.on('ai:updateStreamExecutionPolicy', (_, channelId: string, fullExecuteEnabled: boolean) => {
+    if (!channelId || typeof channelId !== 'string') return
+    if (!activeStreams.has(channelId)) return
+    streamRuntimeFullExecute.set(channelId, fullExecuteEnabled === true)
   })
 
   // Stop streaming
@@ -5158,6 +5173,7 @@ If you find yourself frequently hitting limits, suggest breaking the task into m
       activeStreams.delete(channelId)
     }
     streamRuntimeModes.delete(channelId)
+    streamRuntimeFullExecute.delete(channelId)
 
     // Cancel running sub-agents immediately when user stops
     const cancelled = cancelAgentsForStream(channelId)

--- a/electron/ipc/logs.ts
+++ b/electron/ipc/logs.ts
@@ -1,0 +1,24 @@
+import { clipboard, dialog, ipcMain } from 'electron'
+import fs from 'fs'
+
+export function registerLogHandlers() {
+  ipcMain.handle('logs:copyConversationLog', async (_, markdown: string) => {
+    clipboard.writeText(markdown || '')
+    return { success: true }
+  })
+
+  ipcMain.handle('logs:saveConversationLog', async (_, defaultFileName: string, markdown: string) => {
+    const result = await dialog.showSaveDialog({
+      title: 'Save Conversation Log',
+      defaultPath: defaultFileName || 'jelico-conversation-log.md',
+      filters: [{ name: 'Markdown', extensions: ['md'] }],
+    })
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, canceled: true }
+    }
+
+    fs.writeFileSync(result.filePath, markdown || '', 'utf8')
+    return { success: true, filePath: result.filePath }
+  })
+}

--- a/electron/ipc/providers.ts
+++ b/electron/ipc/providers.ts
@@ -383,6 +383,7 @@ function toApiFormat(row: any) {
     defaultModel: row.default_model,
     hiddenFromSelector: row.hidden_from_selector === 1,
     capabilityProfiles: row.capability_profiles || null,
+    modelToolCapabilities: (row as any).model_tool_capabilities || null,
     defaultReasoningEffort: row.default_reasoning_effort || null,
     isDefault: row.is_default === 1,
     createdAt: row.created_at,
@@ -718,6 +719,7 @@ export function registerProviderHandlers() {
       baseUrl: input.baseUrl,
       defaultModel: input.defaultModel,
       capabilityProfiles: input.capabilityProfiles,
+      modelToolCapabilities: input.modelToolCapabilities,
       defaultReasoningEffort: input.defaultReasoningEffort,
       isDefault: input.isDefault,
     })
@@ -735,6 +737,7 @@ export function registerProviderHandlers() {
     const provider = providerDb.update(id, {
       ...updates,
       capabilityProfiles: updates.capabilityProfiles,
+      modelToolCapabilities: updates.modelToolCapabilities,
       defaultReasoningEffort: updates.defaultReasoningEffort,
     })
 
@@ -1321,5 +1324,168 @@ export function registerProviderHandlers() {
 
   ipcMain.handle('keychain:delete', async (_, providerId: string) => {
     return await keychainService.deleteApiKey(providerId)
+  })
+
+  ipcMain.handle('providers:getModelToolCapability', async (_, providerId: string, modelId: string) => {
+    const provider = providerDb.get(providerId)
+    if (!provider) {
+      return {
+        support: 'unknown',
+        label: 'Tool support unknown',
+        source: 'unknown',
+        reason: 'Provider not found.',
+      }
+    }
+
+    const cached = (provider as any).model_tool_capabilities?.[modelId]
+    if (cached) return cached
+
+    const type = String(provider.type || '').toLowerCase()
+    const name = String(provider.name || '').toLowerCase()
+    const baseUrl = String(provider.base_url || '').toLowerCase()
+
+    if (type.includes('nous') || name.includes('nous') || baseUrl.includes('portal.nousresearch.com')) {
+      return {
+        support: 'chat_only',
+        label: 'Chat only',
+        source: 'explicit',
+        reason: 'This compatible endpoint is known to expose chat responses without reliable structured tool calls.',
+      }
+    }
+
+    if (['openai', 'anthropic', 'google'].includes(type)) {
+      return {
+        support: 'tools_supported',
+        label: 'Tools supported',
+        source: 'provider',
+        reason: 'Native provider integration supports structured tool calls.',
+      }
+    }
+
+    return {
+      support: 'unknown',
+      label: 'Tool support unknown',
+      source: 'unknown',
+      reason: 'Tool support has not been verified for this provider and model.',
+    }
+  })
+
+  ipcMain.handle('providers:verifyModelToolCapability', async (_, providerId: string, modelId: string) => {
+    const provider = providerDb.get(providerId)
+    if (!provider) {
+      return {
+        support: 'unknown',
+        label: 'Tool support unknown',
+        source: 'unknown',
+        reason: 'Provider not found.',
+      }
+    }
+
+    const result = ['openai', 'anthropic', 'google'].includes(String(provider.type || '').toLowerCase())
+      ? {
+          support: 'tools_supported',
+          label: 'Tools supported',
+          source: 'verified',
+          reason: 'Native provider integration is verified as tool-capable.',
+        }
+      : await (async () => {
+          const type = String(provider.type || '').toLowerCase()
+          const name = String(provider.name || '').toLowerCase()
+          const baseUrl = String(provider.base_url || '').toLowerCase()
+          if (type.includes('nous') || name.includes('nous') || baseUrl.includes('portal.nousresearch.com')) {
+            return {
+              support: 'chat_only',
+              label: 'Chat only',
+              source: 'explicit',
+              reason: 'This compatible endpoint is known to expose chat responses without reliable structured tool calls.',
+            }
+          }
+
+          if (
+            type === 'openai-compatible' ||
+            type === 'zai' ||
+            type === 'zai-china' ||
+            type === 'zai-coding' ||
+            type === 'zai-coding-china' ||
+            type === 'minimax'
+          ) {
+            try {
+              const apiKey = await keychainService.getApiKey(providerId)
+              if (!apiKey) throw new Error('API key not found.')
+              const endpoint = buildCompatibleChatCompletionsEndpoint(provider.base_url)
+              if (!endpoint) throw new Error('Provider base URL is not configured.')
+              const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Authorization: `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                  model: modelId,
+                  messages: [
+                    { role: 'user', content: 'Call the provided tool with ok=true.' },
+                  ],
+                  tools: [
+                    {
+                      type: 'function',
+                      function: {
+                        name: 'jelico_tool_probe',
+                        description: 'Tool support probe.',
+                        parameters: {
+                          type: 'object',
+                          properties: { ok: { type: 'boolean' } },
+                          required: ['ok'],
+                        },
+                      },
+                    },
+                  ],
+                  tool_choice: { type: 'function', function: { name: 'jelico_tool_probe' } },
+                  max_tokens: 64,
+                }),
+              })
+
+              const text = await response.text()
+              if (!response.ok) throw new Error(`Probe failed with HTTP ${response.status}: ${text.slice(0, 200)}`)
+              const payload = JSON.parse(text)
+              const toolCalls = payload?.choices?.[0]?.message?.tool_calls
+              if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+                return {
+                  support: 'tools_supported',
+                  label: 'Tools supported',
+                  source: 'verified',
+                  reason: 'Active provider probe returned a structured tool call for this exact model.',
+                }
+              }
+
+              return {
+                support: 'unknown',
+                label: 'Tool support unknown',
+                source: 'unknown',
+                reason: 'Active provider probe completed but did not return a structured tool call.',
+              }
+            } catch (error) {
+              return {
+                support: 'unknown',
+                label: 'Tool support unknown',
+                source: 'unknown',
+                reason: error instanceof Error ? error.message : 'Active provider probe failed.',
+              }
+            }
+          }
+
+          return {
+            support: 'unknown',
+            label: 'Tool support unknown',
+            source: 'unknown',
+            reason: 'Active verification is not available for this provider type yet.',
+          }
+        })()
+
+    const nextCapabilities = {
+      ...(((provider as any).model_tool_capabilities || {}) as Record<string, unknown>),
+      [modelId]: result,
+    }
+    providerDb.update(providerId, { modelToolCapabilities: nextCapabilities } as any)
+    return result
   })
 }

--- a/electron/ipc/providers.ts
+++ b/electron/ipc/providers.ts
@@ -1414,8 +1414,11 @@ export function registerProviderHandlers() {
               if (!apiKey) throw new Error('API key not found.')
               const endpoint = buildCompatibleChatCompletionsEndpoint(provider.base_url)
               if (!endpoint) throw new Error('Provider base URL is not configured.')
+              const probeAbort = new AbortController()
+              const probeTimeout = setTimeout(() => probeAbort.abort(), 10_000)
               const response = await fetch(endpoint, {
                 method: 'POST',
+                signal: probeAbort.signal,
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: `Bearer ${apiKey}`,
@@ -1443,6 +1446,7 @@ export function registerProviderHandlers() {
                   max_tokens: 64,
                 }),
               })
+              clearTimeout(probeTimeout)
 
               const text = await response.text()
               if (!response.ok) throw new Error(`Probe failed with HTTP ${response.status}: ${text.slice(0, 200)}`)

--- a/electron/lib/modeCapabilities.ts
+++ b/electron/lib/modeCapabilities.ts
@@ -10,6 +10,11 @@ export interface ModeCapabilities {
   subAgent: ToolMutationPolicy
 }
 
+export interface ExecutionPolicy {
+  mode: AgentMode
+  fullExecuteEnabled?: boolean
+}
+
 let capabilityMatrixValidated = false
 
 // Single capability source of truth used by:
@@ -51,8 +56,21 @@ export function getModeCapabilities(mode: AgentMode): ModeCapabilities {
   return MODE_CAPABILITY_MATRIX[mode] || MODE_CAPABILITY_MATRIX.auto
 }
 
+export function getEffectiveModeCapabilities(policy: AgentMode | ExecutionPolicy): ModeCapabilities {
+  const mode = typeof policy === 'string' ? policy : policy.mode
+  const fullExecuteEnabled = typeof policy === 'string' ? mode === 'execute' : policy.fullExecuteEnabled === true
+  if (!fullExecuteEnabled) {
+    return getModeCapabilities(mode === 'execute' ? 'auto' : mode)
+  }
+
+  return {
+    main: { canWriteFiles: true, canExecuteCommands: true },
+    subAgent: { canWriteFiles: true, canExecuteCommands: true },
+  }
+}
+
 export function canSubAgentMutate(mode: AgentMode): boolean {
-  const caps = getModeCapabilities(mode).subAgent
+  const caps = getEffectiveModeCapabilities(mode).subAgent
   return caps.canWriteFiles || caps.canExecuteCommands
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,6 +20,7 @@ import { registerSpeechHandlers } from './ipc/speech'
 import { registerCompactionHandlers } from './ipc/compaction'
 import { registerUpdateHandlers } from './ipc/updates'
 import { registerWindowHandlers } from './ipc/window'
+import { registerLogHandlers } from './ipc/logs'
 import { closeAllArtifactTestSessions } from './services/artifactTester'
 
 const APP_DISPLAY_NAME = 'Jelico'
@@ -408,6 +409,7 @@ if (gotSingleInstanceLock) {
     registerCompactionHandlers()
     registerUpdateHandlers()
     registerWindowHandlers()
+    registerLogHandlers()
 
     // Create window
     createWindow()

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -18,6 +18,10 @@ contextBridge.exposeInMainWorld('jelico', {
       ipcRenderer.invoke('providers:getModelLimits', providerId, modelId),
     getModelContextSize: (providerId: string, modelId: string) =>
       ipcRenderer.invoke('providers:getModelContextSize', providerId, modelId),
+    getModelToolCapability: (providerId: string, modelId: string) =>
+      ipcRenderer.invoke('providers:getModelToolCapability', providerId, modelId),
+    verifyModelToolCapability: (providerId: string, modelId: string) =>
+      ipcRenderer.invoke('providers:verifyModelToolCapability', providerId, modelId),
   },
   keychain: {
     setApiKey: (providerId: string, key: string) => ipcRenderer.invoke('keychain:set', providerId, key),
@@ -49,6 +53,11 @@ contextBridge.exposeInMainWorld('jelico', {
   queue: {
     list: () => ipcRenderer.invoke('queue:list'),
     replaceAll: (queuedMessages: any[]) => ipcRenderer.invoke('queue:replaceAll', queuedMessages),
+  },
+  logs: {
+    copyConversationLog: (markdown: string) => ipcRenderer.invoke('logs:copyConversationLog', markdown),
+    saveConversationLog: (defaultFileName: string, markdown: string) =>
+      ipcRenderer.invoke('logs:saveConversationLog', defaultFileName, markdown),
   },
   workspaces: {
     list: () => ipcRenderer.invoke('workspaces:list'),
@@ -396,6 +405,9 @@ contextBridge.exposeInMainWorld('jelico', {
     },
     updateStreamMode: (channelId: string, mode: 'auto' | 'explore' | 'execute' | 'plan' | 'review') => {
       ipcRenderer.send('ai:updateStreamMode', channelId, mode)
+    },
+    updateStreamExecutionPolicy: (channelId: string, fullExecuteEnabled: boolean) => {
+      ipcRenderer.send('ai:updateStreamExecutionPolicy', channelId, fullExecuteEnabled)
     },
     stopStream: (channelId: string) => {
       ipcRenderer.send('ai:stop', channelId)

--- a/electron/services/database.ts
+++ b/electron/services/database.ts
@@ -81,6 +81,9 @@ function loadDb(): void {
           if (provider.default_reasoning_effort === undefined) {
             provider.default_reasoning_effort = null
           }
+          if (provider.model_tool_capabilities === undefined) {
+            provider.model_tool_capabilities = null
+          }
         })
       }
       // Conversation archive migration: legacy rows had no archived_at field.

--- a/electron/services/database.ts
+++ b/electron/services/database.ts
@@ -350,6 +350,7 @@ export const providerDb = {
       default_model: provider.defaultModel,
       hidden_from_selector: provider.hiddenFromSelector ? 1 : 0,
       capability_profiles: provider.capabilityProfiles || null,
+      model_tool_capabilities: provider.modelToolCapabilities || null,
       default_reasoning_effort: provider.defaultReasoningEffort || null,
       is_default: isDefault ? 1 : 0,
       created_at: now,
@@ -378,6 +379,7 @@ export const providerDb = {
     if (updates.defaultModel !== undefined) provider.default_model = updates.defaultModel
     if (updates.hiddenFromSelector !== undefined) provider.hidden_from_selector = updates.hiddenFromSelector ? 1 : 0
     if (updates.capabilityProfiles !== undefined) provider.capability_profiles = updates.capabilityProfiles || null
+    if (updates.modelToolCapabilities !== undefined) provider.model_tool_capabilities = updates.modelToolCapabilities || null
     if (updates.defaultReasoningEffort !== undefined) provider.default_reasoning_effort = updates.defaultReasoningEffort || null
     if (updates.isDefault !== undefined) provider.is_default = updates.isDefault ? 1 : 0
     provider.updated_at = now
@@ -740,6 +742,7 @@ interface ProviderRow {
   default_model: string
   hidden_from_selector: number
   capability_profiles?: Record<string, unknown> | null
+  model_tool_capabilities?: Record<string, unknown> | null
   default_reasoning_effort: string | null
   is_default: number
   created_at: number
@@ -753,6 +756,7 @@ interface ProviderInput {
   defaultModel: string
   hiddenFromSelector?: boolean
   capabilityProfiles?: Record<string, unknown>
+  modelToolCapabilities?: Record<string, unknown>
   defaultReasoningEffort?: string | null
   isDefault?: boolean
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jelico",
-  "version": "0.39.2",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jelico",
-      "version": "0.39.2",
+      "version": "0.40.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jelico",
-  "version": "0.39.2",
+  "version": "0.40.0",
   "description": "AI Productivity Desktop - Get stuff done. Frictionlessly.",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState, useRef, type CSSProperties } from 'react'
+import { useEffect, useCallback, useState, useRef } from 'react'
 import { ArrowUpRight, Download, PanelLeftClose, PanelLeftOpen, RefreshCw, X } from 'lucide-react'
 import { useProviderStore } from './stores/providers'
 import { useChatStore } from './stores/chat'
@@ -28,6 +28,7 @@ import { PermissionDialog } from './components/Permissions/PermissionDialog'
 import { ClarificationPanel } from './components/Clarification/ClarificationPanel'
 import { WelcomeScreen, type OnboardingProfile } from './components/Onboarding/WelcomeScreen'
 import { ToastViewport } from './components/Feedback/ToastViewport'
+import { ContextMenu, type ContextMenuItem } from './components/Common/ContextMenu'
 
 // Default and constraints for canvas panel width
 const DEFAULT_CANVAS_WIDTH = 500
@@ -69,11 +70,11 @@ interface FontShortcutState {
 
 export default function App() {
   const isMacPlatform = navigator.platform.toUpperCase().includes('MAC')
-  const macDragRegionStyle = isMacPlatform ? ({ WebkitAppRegion: 'drag' } as CSSProperties) : {}
   const { providers, loadProviders, isLoading } = useProviderStore()
   const { loadConversations, activeConversationId, messages, isStreaming, conversationStreams } = useChatStore()
   const {
     settingsOpen,
+    openSettings,
     closeSettings,
     providerSetupOpen,
     closeProviderSetup,
@@ -84,7 +85,8 @@ export default function App() {
     appFontPt,
     setAppFontPt,
   } = useUIStore()
-  const { canvasOpen } = useArtifactStore()
+  const { canvasOpen, toggleCanvas } = useArtifactStore()
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null)
   const { loadWorkspaces } = useWorkspaceStore()
   const { clearOncePermissions, loadPermissions } = usePermissionStore()
   const { loadSkills } = useSkillStore()
@@ -505,6 +507,22 @@ export default function App() {
       className="h-screen flex bg-bg-void text-text-primary overflow-hidden relative select-none app-font-scale"
       onDoubleClick={handleAppDoubleClick}
       onMouseDown={handleAppMouseDown}
+      onContextMenu={(event) => {
+        const target = event.target as HTMLElement | null
+        if (!target || target.closest('button,a,input,textarea,select,[role="button"],[data-context-menu-surface]')) return
+        event.preventDefault()
+        setContextMenu({
+          x: event.clientX,
+          y: event.clientY,
+          items: [
+            { label: 'New Chat', onClick: () => useChatStore.getState().setActiveConversation(null) },
+            { label: 'Settings', onClick: () => openSettings() },
+            { label: 'Provider Settings', onClick: () => openSettings('providers') },
+            { label: sidebarCollapsed ? 'Expand Sidebar' : 'Collapse Sidebar', onClick: toggleSidebar },
+            { label: canvasOpen ? 'Hide Canvas' : 'Show Canvas', onClick: toggleCanvas },
+          ],
+        })
+      }}
     >
       {/* Floating sidebar toggle button at left edge */}
       <button
@@ -527,20 +545,7 @@ export default function App() {
 
       <Sidebar />
 
-      <main
-        className="relative flex-1 flex flex-col min-w-0"
-        style={{ paddingTop: 'var(--titlebar-padding)' }}
-      >
-        {/* macOS titlebar safe-area fill for the main pane */}
-        <div
-          className={`pane-surface absolute top-0 left-0 right-0 ${isMacPlatform ? '' : 'pointer-events-none'}`}
-          style={{
-            height: 'var(--titlebar-padding)',
-            ...macDragRegionStyle,
-          }}
-          aria-hidden="true"
-        />
-
+      <main className="relative flex-1 flex flex-col min-w-0">
         {!showNewChatUI && <Header />}
         <div className="flex-1 flex min-h-0">
           <div className="flex-1 flex flex-col min-w-0">
@@ -614,6 +619,15 @@ export default function App() {
 
       {/* App-level decision prompt dialog */}
       <DecisionPromptDialog />
+
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={contextMenu.items}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
 
       {(showApplyBanner || showAvailableBanner) && (
         <div className="fixed bottom-4 right-4 z-[70] w-[min(90vw,420px)]" data-window-toggle="ignore">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -510,6 +510,8 @@ export default function App() {
       onContextMenu={(event) => {
         const target = event.target as HTMLElement | null
         if (!target || target.closest('button,a,input,textarea,select,[role="button"],[data-context-menu-surface]')) return
+        if (window.getSelection()?.toString()) return
+        if (target.closest('.select-text')) return
         event.preventDefault()
         setContextMenu({
           x: event.clientX,

--- a/src/components/Chat/ChatArea.tsx
+++ b/src/components/Chat/ChatArea.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState, useMemo, useCallback, useLayoutEffect } from 'react'
-import { Settings, Loader2 } from 'lucide-react'
+import { Settings, Settings2, Loader2 } from 'lucide-react'
 import { useChatStore } from '../../stores/chat'
 import { useProviderStore } from '../../stores/providers'
 import { useUIStore } from '../../stores/ui'
@@ -1292,6 +1292,13 @@ function NewChatView({ disabled, isStreaming }: NewChatViewProps) {
           </label>
         )}
         <ModelSelector compact />
+        <button
+          onClick={() => openSettings('providers')}
+          className="p-2 text-text-muted hover:text-text-primary hover:bg-bg-surface rounded-md transition-colors"
+          title="Provider settings"
+        >
+          <Settings2 className="w-5 h-5" />
+        </button>
         <button
           onClick={() => openSettings()}
           className="p-2 text-text-muted hover:text-text-primary hover:bg-bg-surface rounded-md transition-colors"

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, KeyboardEvent, useMemo, DragEvent, useEffect, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { SendHorizontal, Square, Clock, Paperclip, X, Trash2, FileText, Image, File as FileIcon, ChevronUp, ChevronDown, Edit3 } from 'lucide-react'
+import { SendHorizontal, Square, Clock, Paperclip, X, Trash2, FileText, Image, File as FileIcon, ChevronUp, ChevronDown, Edit3, ShieldAlert } from 'lucide-react'
 import { useChatStore, type MessageAttachment, type QueuedMessage } from '../../stores/chat'
 import { useProviderStore } from '../../stores/providers'
 import { useContextStore } from '../../stores/context'
@@ -296,6 +296,8 @@ export function ChatInput({
     queuePanelExpandedByConversation,
     setQueuePanelExpanded,
     activeConversationId,
+    fullExecuteEnabled,
+    setFullExecuteEnabled,
   } = useChatStore()
   const { activeProviderId, activeModel } = useProviderStore()
   const { isConversationCompacting } = useContextStore()
@@ -500,6 +502,25 @@ export function ChatInput({
 
     resizeTextarea(nextValue)
   }, [activeConversationId, attachments, resizeTextarea])
+
+  useEffect(() => {
+    const handleReferenceArtifact = (event: Event) => {
+      const customEvent = event as CustomEvent<{ id: string; title: string; type: string }>
+      const artifact = customEvent.detail
+      if (!artifact?.id) return
+      const reference = `Reference artifact "${artifact.title}" (id: ${artifact.id}, type: ${artifact.type}).`
+      setInput((current) => {
+        const separator = current.trim().length > 0 ? '\n\n' : ''
+        const next = `${current}${separator}${reference}`
+        persistDraft(next, attachments)
+        return next
+      })
+      requestAnimationFrame(() => focusTextarea())
+    }
+
+    window.addEventListener('jelico:reference-artifact', handleReferenceArtifact)
+    return () => window.removeEventListener('jelico:reference-artifact', handleReferenceArtifact)
+  }, [attachments, focusTextarea, persistDraft])
 
   useEffect(() => {
     const draftKey = getDraftKey(activeConversationId)
@@ -1099,6 +1120,23 @@ export function ChatInput({
           {/* Right side - Send button */}
           <div className="flex min-w-max items-center justify-end gap-2">
             <ReasoningSelector compact menuDirection="up" menuAlign="right" variant="composer" />
+
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation()
+                setFullExecuteEnabled(!fullExecuteEnabled)
+              }}
+              className={`inline-flex h-[2.2em] items-center gap-1.5 rounded-full border px-3 text-[0.76rem] font-medium transition-colors ${
+                fullExecuteEnabled
+                  ? 'border-warning/70 bg-warning/15 text-warning'
+                  : 'border-border-subtle bg-bg-surface text-text-muted hover:border-border-strong hover:text-text-secondary'
+              }`}
+              title={fullExecuteEnabled ? 'Full Execute is enabled' : 'Enable Full Execute'}
+            >
+              <ShieldAlert className="h-[1em] w-[1em]" />
+              <span>Full Execute</span>
+            </button>
 
             {/* Speech-to-text disabled - WASM crashes on Windows ARM64, will revisit later */}
 

--- a/src/components/Common/ContextMenu.tsx
+++ b/src/components/Common/ContextMenu.tsx
@@ -17,14 +17,14 @@ interface ContextMenuProps {
 
 export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   useEffect(() => {
-    const close = () => onClose()
-    window.addEventListener('mousedown', close)
-    window.addEventListener('blur', close)
-    window.addEventListener('keydown', close)
+    const handleKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('mousedown', onClose)
+    window.addEventListener('blur', onClose)
+    window.addEventListener('keydown', handleKeyDown)
     return () => {
-      window.removeEventListener('mousedown', close)
-      window.removeEventListener('blur', close)
-      window.removeEventListener('keydown', close)
+      window.removeEventListener('mousedown', onClose)
+      window.removeEventListener('blur', onClose)
+      window.removeEventListener('keydown', handleKeyDown)
     }
   }, [onClose])
 
@@ -37,9 +37,9 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
       style={{ left: x, top: y }}
       onMouseDown={(event) => event.stopPropagation()}
     >
-      {items.map((item) => (
+      {items.map((item, index) => (
         <button
-          key={item.label}
+          key={index}
           disabled={item.disabled}
           className={`block w-full px-3 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
             item.danger

--- a/src/components/Common/ContextMenu.tsx
+++ b/src/components/Common/ContextMenu.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+export interface ContextMenuItem {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  danger?: boolean
+}
+
+interface ContextMenuProps {
+  x: number
+  y: number
+  items: ContextMenuItem[]
+  onClose: () => void
+}
+
+export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
+  useEffect(() => {
+    const close = () => onClose()
+    window.addEventListener('mousedown', close)
+    window.addEventListener('blur', close)
+    window.addEventListener('keydown', close)
+    return () => {
+      window.removeEventListener('mousedown', close)
+      window.removeEventListener('blur', close)
+      window.removeEventListener('keydown', close)
+    }
+  }, [onClose])
+
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      className="fixed z-[1000] min-w-[12rem] overflow-hidden rounded-lg border border-border bg-bg-elevated py-1 text-sm shadow-xl"
+      data-context-menu-surface="true"
+      style={{ left: x, top: y }}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      {items.map((item) => (
+        <button
+          key={item.label}
+          disabled={item.disabled}
+          className={`block w-full px-3 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+            item.danger
+              ? 'text-error hover:bg-error/10'
+              : 'text-text-secondary hover:bg-bg-hover hover:text-text-primary'
+          }`}
+          onClick={() => {
+            if (item.disabled) return
+            item.onClick()
+            onClose()
+          }}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>,
+    document.body
+  )
+}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from 'react'
-import { Settings, Presentation, GitBranch } from 'lucide-react'
+import { Settings, Settings2, PanelLeftOpen, GitBranch } from 'lucide-react'
 import { useUIStore } from '../../stores/ui'
 import { useArtifactStore } from '../../stores/artifacts'
 import { useChatStore } from '../../stores/chat'
@@ -41,6 +41,13 @@ export function Header() {
       >
         <WorkspaceSelector />
         <ModelSelector />
+        <button
+          onClick={() => openSettings('providers')}
+          className="p-[0.45em] text-sm text-text-muted hover:text-text-primary hover:bg-bg-surface rounded-md transition-colors"
+          title="Provider settings"
+        >
+          <Settings2 className="w-[1.05em] h-[1.05em]" />
+        </button>
         <ContextIndicator />
         {activeBranch && (
           <div
@@ -69,7 +76,7 @@ export function Header() {
           `}
           title={canvasOpen ? 'Hide Canvas' : 'Show Canvas'}
         >
-          <Presentation className="w-[1.15em] h-[1.15em]" />
+          <PanelLeftOpen className="w-[1.15em] h-[1.15em]" />
           {currentConversationArtifacts.length > 0 && !canvasOpen && (
             <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-accent rounded-full" />
           )}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import {
   Plus,
   Settings,
@@ -231,6 +231,9 @@ export function Sidebar() {
   // Track which conversations have their artifact trees expanded
   const [expandedConversations, setExpandedConversations] = useState<Set<string>>(new Set())
   const [archiveConfirmConversationId, setArchiveConfirmConversationId] = useState<string | null>(null)
+  const [renamingConvId, setRenamingConvId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const renameInputRef = useRef<HTMLInputElement | null>(null)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null)
   // Transfer dialog state
   const [transferDialogConv, setTransferDialogConv] = useState<{ id: string; title: string; workspaceId: string | null } | null>(null)
@@ -486,6 +489,14 @@ export function Sidebar() {
     }
   }
 
+  const submitRename = async (convId: string, value: string) => {
+    const next = value.trim()
+    setRenamingConvId(null)
+    if (!next) return
+    await window.jelico.conversations.updateTitle(convId, next)
+    await useChatStore.getState().loadConversations()
+  }
+
   const openConversationContextMenu = (event: React.MouseEvent, conv: ChatConversation) => {
     event.preventDefault()
     event.stopPropagation()
@@ -496,11 +507,12 @@ export function Sidebar() {
         { label: 'Open Chat', onClick: () => setActiveConversation(conv.id) },
         {
           label: 'Rename',
-          onClick: async () => {
-            const nextTitle = window.prompt('Rename chat', conv.title)
-            if (!nextTitle?.trim()) return
-            await window.jelico.conversations.updateTitle(conv.id, nextTitle.trim())
-            await useChatStore.getState().loadConversations()
+          onClick: () => {
+            setRenameValue(conv.title)
+            setRenamingConvId(conv.id)
+            requestAnimationFrame(() => {
+              renameInputRef.current?.select()
+            })
           },
         },
         { label: 'Copy Logs', onClick: () => void collectLogs(conv, 'copy') },
@@ -727,9 +739,25 @@ export function Sidebar() {
                                       aria-hidden="true"
                                     />
                                   )}
-                                  <span className={`break-words ${isArchiveConfirming ? 'font-medium' : ''}`}>
-                                    {isArchiveConfirming ? `Archive "${conv.title}"?` : conv.title}
-                                  </span>
+                                  {renamingConvId === conv.id ? (
+                                    <input
+                                      ref={renameInputRef}
+                                      value={renameValue}
+                                      onChange={(e) => setRenameValue(e.target.value)}
+                                      onBlur={() => void submitRename(conv.id, renameValue)}
+                                      onKeyDown={(e) => {
+                                        if (e.key === 'Enter') { e.preventDefault(); void submitRename(conv.id, renameValue) }
+                                        if (e.key === 'Escape') { e.preventDefault(); setRenamingConvId(null) }
+                                      }}
+                                      onClick={(e) => e.stopPropagation()}
+                                      className="w-full bg-bg-elevated border border-accent/60 rounded px-1 py-0 text-sm text-text-primary focus:outline-none focus:border-accent"
+                                      autoFocus
+                                    />
+                                  ) : (
+                                    <span className={`break-words ${isArchiveConfirming ? 'font-medium' : ''}`}>
+                                      {isArchiveConfirming ? `Archive "${conv.title}"?` : conv.title}
+                                    </span>
+                                  )}
                                 </div>
 
                                 {!isArchiveConfirming && isWorktreeConversation && (

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, type CSSProperties } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import {
   Plus,
   Settings,
@@ -29,6 +29,8 @@ import { useArtifactStore, type ArtifactType } from '../../stores/artifacts'
 import { useToastStore } from '../../stores/toasts'
 import { useUpdateStore } from '../../stores/updates'
 import { TransferDialog } from '../Conversations/TransferDialog'
+import { ContextMenu, type ContextMenuItem } from '../Common/ContextMenu'
+import { buildConversationLog } from '../../lib/conversationLog'
 import {
   CONVERSATION_SIDEBAR_STATUS_ORDER,
   getConversationSidebarStatus,
@@ -210,8 +212,6 @@ export function Sidebar() {
   const { artifacts, selectArtifact, openCanvas } = useArtifactStore()
   const addToast = useToastStore((state) => state.addToast)
   const updateAvailable = useUpdateStore((state) => state.info?.isUpdateAvailable)
-  const isMacPlatform = useMemo(() => navigator.platform.toUpperCase().includes('MAC'), [])
-  const macDragRegionStyle = isMacPlatform ? ({ WebkitAppRegion: 'drag' } as CSSProperties) : {}
   // Track which project groups are expanded (persisted to localStorage)
   const SIDEBAR_COLLAPSED_KEY = 'jelico:sidebar:collapsed-groups'
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => {
@@ -231,6 +231,7 @@ export function Sidebar() {
   // Track which conversations have their artifact trees expanded
   const [expandedConversations, setExpandedConversations] = useState<Set<string>>(new Set())
   const [archiveConfirmConversationId, setArchiveConfirmConversationId] = useState<string | null>(null)
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; items: ContextMenuItem[] } | null>(null)
   // Transfer dialog state
   const [transferDialogConv, setTransferDialogConv] = useState<{ id: string; title: string; workspaceId: string | null } | null>(null)
 
@@ -441,6 +442,113 @@ export function Sidebar() {
     })
   }
 
+  const collectLogs = async (conv: ChatConversation, action: 'copy' | 'save') => {
+    try {
+      const conversation = await window.jelico.conversations.get(conv.id)
+      if (!conversation) throw new Error('Conversation not found')
+      const rows = await window.jelico.artifacts.getByConversation(conv.id)
+      const log = buildConversationLog({
+        conversation,
+        artifacts: rows.map((row: any) => ({
+          id: row.id,
+          conversationId: row.conversation_id || undefined,
+          type: row.type,
+          title: row.title,
+          content: row.content,
+          language: row.language || undefined,
+          filePath: row.file_path || undefined,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+          baseArtifactId: row.base_artifact_id || undefined,
+          revision: row.revision || 1,
+        })),
+      })
+
+      if (action === 'copy') {
+        await window.jelico.logs.copyConversationLog(log)
+        addToast({ title: 'Log copied', description: conv.title, variant: 'success', durationMs: 3200 })
+      } else {
+        const fileName = `${conv.title || 'jelico-conversation'}`
+          .replace(/[<>:"/\\|?*]+/g, '-')
+          .slice(0, 80) + '.md'
+        const result = await window.jelico.logs.saveConversationLog(fileName, log)
+        if (!result.canceled) {
+          addToast({ title: 'Log saved', description: result.filePath || conv.title, variant: 'success', durationMs: 3200 })
+        }
+      }
+    } catch (error) {
+      addToast({
+        title: 'Collect logs failed',
+        description: error instanceof Error ? error.message : 'Unable to collect logs.',
+        variant: 'error',
+        durationMs: 4200,
+      })
+    }
+  }
+
+  const openConversationContextMenu = (event: React.MouseEvent, conv: ChatConversation) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setContextMenu({
+      x: event.clientX,
+      y: event.clientY,
+      items: [
+        { label: 'Open Chat', onClick: () => setActiveConversation(conv.id) },
+        {
+          label: 'Rename',
+          onClick: async () => {
+            const nextTitle = window.prompt('Rename chat', conv.title)
+            if (!nextTitle?.trim()) return
+            await window.jelico.conversations.updateTitle(conv.id, nextTitle.trim())
+            await useChatStore.getState().loadConversations()
+          },
+        },
+        { label: 'Copy Logs', onClick: () => void collectLogs(conv, 'copy') },
+        { label: 'Save Logs...', onClick: () => void collectLogs(conv, 'save') },
+        {
+          label: 'Transfer to Workspace',
+          disabled: Boolean(conv.workspaceId),
+          onClick: () => setTransferDialogConv({ id: conv.id, title: conv.title, workspaceId: conv.workspaceId || null }),
+        },
+        { label: 'Archive', danger: true, onClick: () => setArchiveConfirmConversationId(conv.id) },
+      ],
+    })
+  }
+
+  const openArtifactContextMenu = (event: React.MouseEvent, conv: ChatConversation, artifact: ReturnType<typeof getArtifactsForConversation>[number]) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setContextMenu({
+      x: event.clientX,
+      y: event.clientY,
+      items: [
+        {
+          label: 'Open in Canvas',
+          onClick: async () => {
+            await setActiveConversation(conv.id)
+            selectArtifact(artifact.id)
+            openCanvas()
+          },
+        },
+        {
+          label: 'Reference in Prompt',
+          onClick: () => window.dispatchEvent(new CustomEvent('jelico:reference-artifact', {
+            detail: { id: artifact.id, title: artifact.title, type: artifact.type },
+          })),
+        },
+        { label: 'Reveal in Folder', onClick: () => void window.jelico.artifacts.reveal(artifact.id) },
+        {
+          label: 'Delete',
+          danger: true,
+          onClick: () => {
+            if (!window.confirm(`Delete artifact "${artifact.title}"?`)) return
+            void useArtifactStore.getState().removeArtifact(artifact.id)
+          },
+        },
+      ],
+    })
+  }
+
   useEffect(() => {
     if (!archiveConfirmConversationId) return
     if (conversations.some((conversation) => conversation.id === archiveConfirmConversationId)) return
@@ -453,18 +561,7 @@ export function Sidebar() {
   }
 
   return (
-    <div
-      className="pane-surface relative w-64 border-r border-border flex flex-col"
-      style={{ paddingTop: 'var(--titlebar-padding)' }}
-    >
-      <div
-        className="absolute left-0 right-0 top-0 z-10"
-        style={{
-          height: 'var(--titlebar-padding)',
-          ...macDragRegionStyle,
-        }}
-        aria-hidden="true"
-      />
+    <div className="pane-surface relative w-64 border-r border-border flex flex-col">
 
       {/* Header */}
       <div className="p-4">
@@ -586,6 +683,7 @@ export function Sidebar() {
                                   setArchiveConfirmConversationId(null)
                                   setActiveConversation(conv.id)
                                 }}
+                                onContextMenu={(event) => openConversationContextMenu(event, conv)}
                                 title={formatCreatedDate(conv.createdAt)}
                                 style={{
                                   width: 'calc(100% + 0.75rem)',
@@ -687,6 +785,7 @@ export function Sidebar() {
                                     return (
                                       <div
                                         key={artifact.id}
+                                        onContextMenu={(event) => openArtifactContextMenu(event, conv, artifact)}
                                         className="group flex items-center gap-2 px-2 py-1 text-xs text-text-muted hover:text-text-primary hover:bg-bg-hover rounded transition-colors"
                                       >
                                         <button
@@ -772,6 +871,15 @@ export function Sidebar() {
           onTransferComplete={() => {
             // Chat/workspace state is refreshed by the dialog after transfer
           }}
+        />
+      )}
+
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={contextMenu.items}
+          onClose={() => setContextMenu(null)}
         />
       )}
     </div>

--- a/src/components/ModeSelector/ModeSelector.tsx
+++ b/src/components/ModeSelector/ModeSelector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { modes, cycleMode, type AgentMode } from '../../lib/modes'
+import { behaviorModes, cycleMode, normalizeBehaviorMode, type BehaviorMode } from '../../lib/modes'
 import { useChatStore } from '../../stores/chat'
 
 interface ModeSelectorProps {
@@ -8,18 +8,19 @@ interface ModeSelectorProps {
 
 export function ModeSelector({ flatTop = false }: ModeSelectorProps) {
   const { mode, setMode, modeTransitioning } = useChatStore()
-  const [animatingMode, setAnimatingMode] = useState<AgentMode | null>(null)
-  const prevModeRef = useRef(mode)
+  const behaviorMode = normalizeBehaviorMode(mode)
+  const [animatingMode, setAnimatingMode] = useState<BehaviorMode | null>(null)
+  const prevModeRef = useRef(behaviorMode)
 
   // Animate when mode changes
   useEffect(() => {
-    if (mode !== prevModeRef.current) {
-      setAnimatingMode(mode)
+    if (behaviorMode !== prevModeRef.current) {
+      setAnimatingMode(behaviorMode)
       const timer = setTimeout(() => setAnimatingMode(null), 700)
-      prevModeRef.current = mode
+      prevModeRef.current = behaviorMode
       return () => clearTimeout(timer)
     }
-  }, [mode])
+  }, [behaviorMode])
 
   // Handle Tab key to cycle modes
   useEffect(() => {
@@ -39,18 +40,17 @@ export function ModeSelector({ flatTop = false }: ModeSelectorProps) {
 
         e.preventDefault()
         const direction = e.shiftKey ? -1 : 1
-        const newMode = cycleMode(mode, direction)
+        const newMode = cycleMode(behaviorMode, direction)
         setMode(newMode)
       }
 
-      // Number keys 1-5 for direct mode selection
+      // Number keys 1-4 for direct mode selection
       if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
-        const modeKeys: Record<string, AgentMode> = {
+        const modeKeys: Record<string, BehaviorMode> = {
           '1': 'auto',
-          '2': 'execute',
-          '3': 'plan',
-          '4': 'explore',
-          '5': 'review',
+          '2': 'plan',
+          '3': 'explore',
+          '4': 'review',
         }
 
         const modeId = modeKeys[e.key]
@@ -71,7 +71,7 @@ export function ModeSelector({ flatTop = false }: ModeSelectorProps) {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [mode, setMode])
+  }, [behaviorMode, setMode])
 
   return (
     <div className="flex items-center justify-center w-full">
@@ -79,7 +79,7 @@ export function ModeSelector({ flatTop = false }: ModeSelectorProps) {
         flex bg-bg-surface ${flatTop ? 'rounded-t-none rounded-b-lg' : 'rounded-lg'} overflow-hidden p-0 gap-0 transition-all duration-300
         ${modeTransitioning ? 'ring-2 ring-accent/50 ring-offset-2 ring-offset-bg-surface' : ''}
       `}>
-        {Object.values(modes).map((m) => (
+        {Object.values(behaviorModes).map((m) => (
           <button
             key={m.id}
             onClick={() => setMode(m.id)}
@@ -88,7 +88,7 @@ export function ModeSelector({ flatTop = false }: ModeSelectorProps) {
               relative overflow-hidden px-3 py-2 text-sm font-medium
               ${flatTop ? 'first:rounded-bl-lg last:rounded-br-lg' : 'first:rounded-l-lg last:rounded-r-lg'}
               transition-all duration-200
-              ${m.id === mode
+              ${m.id === behaviorMode
                 ? 'bg-accent/22 text-accent shadow-sm ring-1 ring-inset ring-accent z-10'
                 : 'text-text-muted border mode-chip-inactive hover:text-text-secondary'
               }

--- a/src/components/Model/ModelSelector.tsx
+++ b/src/components/Model/ModelSelector.tsx
@@ -5,6 +5,8 @@ import { useChatStore } from '../../stores/chat'
 import { useContextStore } from '../../stores/context'
 import { useProviderStore } from '../../stores/providers'
 import { useUIStore } from '../../stores/ui'
+import { getLocalModelToolCapability } from '../../lib/modelToolCapabilities'
+import { ModelToolCapabilityBadge } from './ModelToolCapabilityBadge'
 
 interface ModelSelectorProps {
   compact?: boolean
@@ -73,6 +75,7 @@ export function ModelSelector({ compact = false }: ModelSelectorProps) {
         providerEndpoint: getProviderEndpointHint(provider.baseUrl),
         model,
         label: `${provider.name} / ${model}`,
+        toolCapability: getLocalModelToolCapability(provider, model),
         isActive: activeProviderId === provider.id && activeModel === model,
       }
     })
@@ -264,6 +267,9 @@ export function ModelSelector({ compact = false }: ModelSelectorProps) {
                   </div>
                   <div className="text-xs text-text-faint whitespace-normal break-all text-left leading-tight mt-0.5">
                     {subtitle}
+                  </div>
+                  <div className="mt-1.5">
+                    <ModelToolCapabilityBadge capability={option.toolCapability} compact />
                   </div>
                 </button>
               )

--- a/src/components/Model/ModelToolCapabilityBadge.tsx
+++ b/src/components/Model/ModelToolCapabilityBadge.tsx
@@ -1,0 +1,26 @@
+import type { ModelToolCapability } from '../../lib/modelToolCapabilities'
+
+interface ModelToolCapabilityBadgeProps {
+  capability: ModelToolCapability
+  compact?: boolean
+}
+
+export function ModelToolCapabilityBadge({ capability, compact = false }: ModelToolCapabilityBadgeProps) {
+  const className =
+    capability.support === 'tools_supported'
+      ? 'border-success/40 bg-success/10 text-success'
+      : capability.support === 'chat_only'
+        ? 'border-warning/50 bg-warning/10 text-warning'
+        : 'border-border-subtle bg-bg-surface text-text-muted'
+
+  return (
+    <span
+      className={`inline-flex max-w-full items-center rounded-full border font-medium leading-none ${className} ${
+        compact ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-1 text-[11px]'
+      }`}
+      title={capability.reason}
+    >
+      {capability.label}
+    </span>
+  )
+}

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -21,6 +21,24 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.40.0',
+    date: '2026-05-11',
+    changes: {
+      added: [
+        'Added focused right-click menus for chats and artifacts, including rename, archive, workspace transfer, artifact reference, reveal, delete, and conversation log actions (Fixes #147, #155)',
+        'Added shareable conversation log collection with copy-to-clipboard and Markdown save options, including messages, tool activity, artifacts, metadata, truncation, and secret redaction (Fixes #155)',
+        'Added model tool-capability labels and warnings so provider setup, settings, and model selection can distinguish tool-capable, chat-only, and unknown models without blocking normal chat (Fixes #173)',
+      ],
+      changed: [
+        'Moved Full Execute out of the primary mode rail into a dedicated composer toggle while keeping Auto, Plan, Explore, and Review as the visible behavior modes (Fixes #153)',
+        'Added provider-settings shortcuts to new and existing chats, refreshed the artifact-pane toggle icon, and removed the extra top-pane spacing above chat content (Fixes #151, #152, #153)',
+      ],
+      fixed: [
+        'Z.ai model setup continues to preserve manually entered model IDs for testing and early-access usage even when live discovery returns a different API-key-scoped model list (Fixes #174)',
+      ],
+    },
+  },
+  {
     version: '0.39.2',
     date: '2026-05-11',
     changes: {

--- a/src/lib/conversationLog.ts
+++ b/src/lib/conversationLog.ts
@@ -1,0 +1,119 @@
+import type { Artifact } from '../stores/artifacts'
+import type { Message } from '../stores/chat'
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/(sk-[A-Za-z0-9_-]{12,})/g, '[REDACTED_OPENAI_KEY]'],
+  [/(xox[baprs]-[A-Za-z0-9-]{12,})/g, '[REDACTED_SLACK_TOKEN]'],
+  [/((?:api[_-]?key|token|secret|password)\s*[:=]\s*)[^\s`'"]+/gi, '$1[REDACTED]'],
+]
+
+function redact(value: string): string {
+  return SECRET_PATTERNS.reduce((next, [pattern, replacement]) => next.replace(pattern, replacement), value)
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function clamp(value: string, limit = 12000): string {
+  const redacted = redact(value)
+  if (redacted.length <= limit) return redacted
+  return `${redacted.slice(0, limit)}\n\n[truncated ${redacted.length - limit} characters]`
+}
+
+function formatTimestamp(value?: number): string {
+  return value ? new Date(value).toISOString() : 'unknown'
+}
+
+export function buildConversationLog(input: {
+  conversation: {
+    id: string
+    title: string
+    providerId?: string
+    model?: string
+    mode?: string
+    createdAt?: number
+    updatedAt?: number
+    messages?: Message[]
+  }
+  artifacts: Artifact[]
+}): string {
+  const { conversation, artifacts } = input
+  const messages = conversation.messages || []
+  const lines: string[] = [
+    `# Jelico Conversation Log: ${conversation.title || 'Untitled chat'}`,
+    '',
+    '## Metadata',
+    `- Conversation ID: ${conversation.id}`,
+    `- Provider ID: ${conversation.providerId || 'unknown'}`,
+    `- Model: ${conversation.model || 'unknown'}`,
+    `- Mode: ${conversation.mode || 'unknown'}`,
+    `- Created: ${formatTimestamp(conversation.createdAt)}`,
+    `- Updated: ${formatTimestamp(conversation.updatedAt)}`,
+    `- Messages: ${messages.length}`,
+    `- Artifacts: ${artifacts.length}`,
+    '',
+    '## Messages',
+  ]
+
+  for (const message of messages) {
+    lines.push('', `### ${message.role.toUpperCase()} - ${formatTimestamp(message.createdAt)}`, '')
+    lines.push(clamp(message.content || '[no text content]'))
+
+    if (message.attachments?.length) {
+      lines.push('', 'Attachments:')
+      for (const attachment of message.attachments) {
+        lines.push(`- ${attachment.name} (${attachment.type}, ${attachment.mimeType})`)
+      }
+    }
+
+    if (message.toolCalls?.length) {
+      lines.push('', 'Tool calls:')
+      for (const call of message.toolCalls) {
+        lines.push(`- ${call.name} (${call.status || 'unknown'})`)
+        lines.push('```json')
+        lines.push(clamp(stringify(call.args), 6000))
+        lines.push('```')
+      }
+    }
+
+    if (message.toolResults?.length) {
+      lines.push('', 'Tool results:')
+      for (const result of message.toolResults) {
+        lines.push(`- ${result.toolCallId}${result.error ? ` error: ${result.error}` : ''}`)
+        lines.push('```json')
+        lines.push(clamp(stringify(result.result), 6000))
+        lines.push('```')
+      }
+    }
+  }
+
+  lines.push('', '## Artifacts')
+  if (artifacts.length === 0) {
+    lines.push('', 'No artifacts.')
+  } else {
+    for (const artifact of artifacts) {
+      lines.push(
+        '',
+        `### ${artifact.title}`,
+        `- ID: ${artifact.id}`,
+        `- Type: ${artifact.type}`,
+        `- Language: ${artifact.language || 'n/a'}`,
+        `- Revision: ${artifact.revision}`,
+        `- Created: ${formatTimestamp(artifact.createdAt)}`,
+        `- Updated: ${formatTimestamp(artifact.updatedAt)}`,
+        '',
+        '```',
+        clamp(artifact.content, 12000),
+        '```'
+      )
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/src/lib/modelToolCapabilities.ts
+++ b/src/lib/modelToolCapabilities.ts
@@ -1,0 +1,60 @@
+export type ModelToolSupport = 'tools_supported' | 'chat_only' | 'unknown'
+
+export interface ModelToolCapability {
+  support: ModelToolSupport
+  label: 'Tools supported' | 'Chat only' | 'Tool support unknown'
+  source: 'explicit' | 'provider' | 'verified' | 'unknown'
+  reason: string
+}
+
+export function getToolCapabilityLabel(support: ModelToolSupport): ModelToolCapability['label'] {
+  if (support === 'tools_supported') return 'Tools supported'
+  if (support === 'chat_only') return 'Chat only'
+  return 'Tool support unknown'
+}
+
+export function getLocalModelToolCapability(provider: {
+  type?: string
+  name?: string
+  baseUrl?: string | null
+  defaultModel?: string | null
+  modelToolCapabilities?: Record<string, ModelToolCapability> | null
+}, modelId?: string | null): ModelToolCapability {
+  const model = modelId?.trim() || provider.defaultModel?.trim() || ''
+  const cached = model ? provider.modelToolCapabilities?.[model] : null
+  if (cached) return cached
+
+  const type = (provider.type || '').toLowerCase()
+  const name = (provider.name || '').toLowerCase()
+  const baseUrl = (provider.baseUrl || '').toLowerCase()
+
+  if (type.includes('nous') || name.includes('nous') || baseUrl.includes('portal.nousresearch.com')) {
+    return {
+      support: 'chat_only',
+      label: 'Chat only',
+      source: 'explicit',
+      reason: 'This compatible endpoint is known to expose chat responses without reliable structured tool calls.',
+    }
+  }
+
+  if (['openai', 'anthropic', 'google'].includes(type)) {
+    return {
+      support: 'tools_supported',
+      label: 'Tools supported',
+      source: 'provider',
+      reason: 'Native provider integration supports structured tool calls.',
+    }
+  }
+
+  return {
+    support: 'unknown',
+    label: 'Tool support unknown',
+    source: 'unknown',
+    reason: 'Tool support has not been verified for this provider and model.',
+  }
+}
+
+export function isLikelyToolTaskPrompt(text: string): boolean {
+  const value = text.toLowerCase()
+  return /\b(read|write|edit|modify|update|create|delete|rename|archive|run|execute|command|terminal|file|folder|directory|workspace|artifact|diagram|html|svg|mermaid|code|fix|implement|build|test|search)\b/.test(value)
+}

--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -1,5 +1,6 @@
 // Mode system - defines how the AI behaves
-export type AgentMode = 'auto' | 'explore' | 'execute' | 'plan' | 'review'
+export type BehaviorMode = 'auto' | 'explore' | 'plan' | 'review'
+export type AgentMode = BehaviorMode | 'execute'
 
 export interface ModeDefinition {
   id: AgentMode
@@ -106,13 +107,24 @@ Explain your findings and provide specific recommendations.`,
   },
 }
 
+export const behaviorModes: Record<BehaviorMode, ModeDefinition> = {
+  auto: modes.auto,
+  plan: modes.plan,
+  explore: modes.explore,
+  review: modes.review,
+}
+
+export function normalizeBehaviorMode(mode: AgentMode): BehaviorMode {
+  return mode === 'execute' ? 'auto' : mode
+}
+
 export function getMode(id: AgentMode): ModeDefinition {
   return modes[id]
 }
 
 export function cycleMode(current: AgentMode, direction: 1 | -1 = 1): AgentMode {
-  const order: AgentMode[] = ['auto', 'execute', 'plan', 'explore', 'review']
-  const idx = order.indexOf(current)
+  const order: BehaviorMode[] = ['auto', 'plan', 'explore', 'review']
+  const idx = order.indexOf(normalizeBehaviorMode(current))
   const next = (idx + direction + order.length) % order.length
   return order[next]
 }

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -1144,7 +1144,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       if (provider) {
         const capability = getLocalModelToolCapability(provider, model)
         if (capability.support !== 'tools_supported') {
-          const warningKey = `tool-capability-warning:${requestedConversationId || 'new'}:${providerId}:${model}:${capability.support}`
+          const warningKey = `tool-capability-warning:${providerId}:${model}:${capability.support}`
           const alreadyAcknowledged = typeof window !== 'undefined' && localStorage.getItem(warningKey) === '1'
           if (!alreadyAcknowledged) {
             const result = await useDecisionPromptStore.getState().request({

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { AgentMode } from '../lib/modes'
+import { normalizeBehaviorMode, type AgentMode } from '../lib/modes'
 import { useArtifactStore } from './artifacts'
 import type { Artifact } from './artifacts'
 import { useWorkspaceStore } from './workspaces'
@@ -15,6 +15,7 @@ import { resolveStreamReasoningEffort } from '../lib/conversationReasoning'
 import { hasIncompleteToolEvidence } from './chatInterruption'
 import { buildSoulLearningMessages } from './chatLearning'
 import { useToastStore } from './toasts'
+import { getLocalModelToolCapability, isLikelyToolTaskPrompt } from '../lib/modelToolCapabilities'
 import {
   getNextProcessableQueuedMessageIndex,
   getPersistableQueuedMessages,
@@ -200,6 +201,7 @@ interface ChatStore {
   isLoading: boolean
   error: string | null
   mode: AgentMode
+  fullExecuteEnabled: boolean
   modeTransitioning: boolean
   modeSwitchReason: string | null
   messageQueue: QueuedMessage[]
@@ -237,6 +239,7 @@ interface ChatStore {
   stopStreaming: () => Promise<void>
   archiveConversation: (id: string) => Promise<void>
   setMode: (mode: AgentMode) => void
+  setFullExecuteEnabled: (enabled: boolean) => void
   setModeTransitioning: (transitioning: boolean) => void
   handleModeSwitch: (fromMode: AgentMode, toMode: AgentMode, reason: string) => void
   clearError: () => void
@@ -413,18 +416,14 @@ async function getPreferredDefaultMode(): Promise<AgentMode> {
 
   try {
     const preference = await window.jelico.soul.getPreference(DEFAULT_MODE_PREFERENCE_KEY)
-    return isAgentMode(preference?.value) ? preference.value : 'auto'
+    return isAgentMode(preference?.value) ? normalizeBehaviorMode(preference.value) : 'auto'
   } catch (error) {
     console.warn('[Chat Store] Failed to load default mode preference, falling back to auto:', error)
     return 'auto'
   }
 }
 
-function isModeTransitionAllowed(currentMode: AgentMode, nextMode: AgentMode): boolean {
-  if (nextMode !== 'execute' || currentMode === 'execute') {
-    return true
-  }
-
+function isFullExecuteTransitionAllowed(): boolean {
   if (typeof window === 'undefined' || typeof window.confirm !== 'function') {
     return true
   }
@@ -802,6 +801,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   isLoading: false,
   error: null,
   mode: 'auto' as AgentMode,
+  fullExecuteEnabled: false,
   messageQueue: [],
   pendingQueuedEdit: null,
   hasHydratedQueuedMessages: false,
@@ -1000,12 +1000,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       useArtifactStore.getState().closeCanvas()
 
       // Reset fresh unsent chats to the user's saved default mode (auto when unset).
-      if (preferredMode === 'execute') {
-        get().setMode('execute')
-        if (get().mode !== 'execute' && currentMode !== 'auto') {
-          set({ mode: 'auto' })
-        }
-      } else if (preferredMode !== currentMode) {
+      if (preferredMode !== currentMode) {
         set({ mode: preferredMode })
       }
       return
@@ -1115,7 +1110,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
   // Internal flag to track if this is a regenerate (skips adding user message)
   sendMessage: async (content, providerId, model, attachments, _isRegenerate = false, _forcedConversationId: string | null = null) => {
-    const { activeConversationId, messages, mode } = get()
+    const { activeConversationId, messages, mode, fullExecuteEnabled } = get()
     const requestedConversationId = _forcedConversationId ?? activeConversationId
     const contextStore = useContextStore.getState()
 
@@ -1144,8 +1139,44 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       return
     }
 
+    if (!_isRegenerate && isLikelyToolTaskPrompt(content)) {
+      const provider = useProviderStore.getState().providers.find((entry) => entry.id === providerId)
+      if (provider) {
+        const capability = getLocalModelToolCapability(provider, model)
+        if (capability.support !== 'tools_supported') {
+          const warningKey = `tool-capability-warning:${requestedConversationId || 'new'}:${providerId}:${model}:${capability.support}`
+          const alreadyAcknowledged = typeof window !== 'undefined' && localStorage.getItem(warningKey) === '1'
+          if (!alreadyAcknowledged) {
+            const result = await useDecisionPromptStore.getState().request({
+              title: capability.label,
+              message: `${provider.name} / ${model} may not support the tools needed for this request.`,
+              detail: capability.reason,
+              options: [
+                { label: 'Send anyway', value: 'send', variant: 'primary' },
+                { label: 'Open Providers', value: 'providers', variant: 'secondary' },
+              ],
+              defaultValue: 'send',
+              cancelValue: 'providers',
+            })
+
+            if (result.value !== 'send') {
+              const { useUIStore } = await import('./ui')
+              useUIStore.getState().openSettings('providers')
+              return
+            }
+
+            try {
+              localStorage.setItem(warningKey, '1')
+            } catch {
+              // Ignore storage failures; the warning will simply be shown again.
+            }
+          }
+        }
+      }
+    }
+
     let finalContent = content
-    const finalMode = mode
+    const finalMode = normalizeBehaviorMode(mode)
 
     let conversationId = requestedConversationId
 
@@ -1422,6 +1453,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         model,
         reasoningEffort: streamReasoningEffort,
         mode: finalMode,
+        fullExecuteEnabled,
         messages: aiMessages,
         workspacePath: activeWorkspace?.path,
         artifacts: artifactContext,
@@ -2786,12 +2818,21 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 
   setMode: (mode) => {
-    const currentMode = get().mode
-    if (mode === currentMode) return
-    if (!isModeTransitionAllowed(currentMode, mode)) return
-    set({ mode })
+    const currentMode = normalizeBehaviorMode(get().mode)
+    const nextMode = normalizeBehaviorMode(mode)
+    if (nextMode === currentMode) return
+    set({ mode: nextMode })
 
     const activeConversationId = get().activeConversationId
+    if (activeConversationId) {
+      const modeNames = { auto: 'Auto', plan: 'Plan', explore: 'Explore', review: 'Review' } as const
+      get().addSystemNotification({
+        type: 'info',
+        conversationId: activeConversationId,
+        message: `Mode changed to ${modeNames[nextMode]}.`,
+      })
+    }
+
     if (!activeConversationId) return
 
     const streamChannelId = streamChannelByConversation.get(activeConversationId)
@@ -2799,9 +2840,37 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     if (!streamChannelId || !streamState?.isStreaming) return
 
     try {
-      window.jelico.ai.updateStreamMode(streamChannelId, mode)
+      window.jelico.ai.updateStreamMode(streamChannelId, nextMode)
     } catch (error) {
       console.warn('[Chat Store] Failed to update active stream mode:', error)
+    }
+  },
+
+  setFullExecuteEnabled: (enabled) => {
+    const current = get().fullExecuteEnabled
+    if (current === enabled) return
+    if (enabled && !isFullExecuteTransitionAllowed()) return
+
+    set({ fullExecuteEnabled: enabled })
+
+    const activeConversationId = get().activeConversationId
+    if (activeConversationId) {
+      get().addSystemNotification({
+        type: 'info',
+        conversationId: activeConversationId,
+        message: enabled ? 'Full Execute enabled.' : 'Full Execute disabled.',
+      })
+    }
+
+    if (!activeConversationId) return
+    const streamChannelId = streamChannelByConversation.get(activeConversationId)
+    const streamState = get().conversationStreams[activeConversationId]
+    if (!streamChannelId || !streamState?.isStreaming) return
+
+    try {
+      window.jelico.ai.updateStreamExecutionPolicy?.(streamChannelId, enabled)
+    } catch (error) {
+      console.warn('[Chat Store] Failed to update active stream execution policy:', error)
     }
   },
 

--- a/src/stores/providers.ts
+++ b/src/stores/providers.ts
@@ -17,6 +17,7 @@ interface ProviderConfig {
   defaultModel: string
   hiddenFromSelector?: boolean
   capabilityProfiles?: Record<string, unknown> | null
+  modelToolCapabilities?: Record<string, import('../lib/modelToolCapabilities').ModelToolCapability> | null
   defaultReasoningEffort?: ReasoningEffort | null
   isDefault: boolean
   createdAt: number
@@ -30,6 +31,7 @@ interface ProviderInput {
   defaultModel: string
   hiddenFromSelector?: boolean
   capabilityProfiles?: Record<string, unknown> | null
+  modelToolCapabilities?: Record<string, import('../lib/modelToolCapabilities').ModelToolCapability> | null
   defaultReasoningEffort?: ReasoningEffort | null
   isDefault?: boolean
   apiKey?: string

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -21,6 +21,8 @@ interface Window {
         modelId: string
       ) => Promise<ModelLimits>
       getModelContextSize: (providerId: string, modelId: string) => Promise<number | null>
+      getModelToolCapability: (providerId: string, modelId: string) => Promise<ModelToolCapability>
+      verifyModelToolCapability: (providerId: string, modelId: string) => Promise<ModelToolCapability>
     }
     keychain: {
       setApiKey: (providerId: string, key: string) => Promise<void>
@@ -54,6 +56,13 @@ interface Window {
     queue: {
       list: () => Promise<QueuedMessageData[]>
       replaceAll: (queuedMessages: QueuedMessageData[]) => Promise<{ success: boolean }>
+    }
+    logs: {
+      copyConversationLog: (markdown: string) => Promise<{ success: boolean }>
+      saveConversationLog: (
+        defaultFileName: string,
+        markdown: string
+      ) => Promise<{ success: boolean; canceled?: boolean; filePath?: string }>
     }
     workspaces: {
       list: () => Promise<Workspace[]>
@@ -134,6 +143,7 @@ interface Window {
       onReasoningStart: (channelId: string, callback: () => void) => void
       onReasoningEnd: (channelId: string, callback: () => void) => void
       updateStreamMode: (channelId: string, mode: 'auto' | 'explore' | 'execute' | 'plan' | 'review') => void
+      updateStreamExecutionPolicy: (channelId: string, fullExecuteEnabled: boolean) => void
       stopStream: (channelId: string) => void
       removeListeners: (channelId: string) => void
       generateTitle: (params: GenerateTitleParams) => Promise<GenerateTitleResult>
@@ -277,6 +287,7 @@ interface ProviderConfig {
   defaultModel: string
   hiddenFromSelector?: boolean
   capabilityProfiles?: Record<string, unknown> | null
+  modelToolCapabilities?: Record<string, ModelToolCapability> | null
   defaultReasoningEffort?: ReasoningEffort | null
   isDefault: boolean
   createdAt: number
@@ -319,6 +330,7 @@ interface ProviderInput {
   defaultModel: string
   hiddenFromSelector?: boolean
   capabilityProfiles?: Record<string, unknown> | null
+  modelToolCapabilities?: Record<string, ModelToolCapability> | null
   defaultReasoningEffort?: ReasoningEffort | null
   isDefault?: boolean
 }
@@ -406,11 +418,21 @@ interface StreamParams {
   model?: string
   reasoningEffort?: ReasoningEffort | null
   mode?: 'auto' | 'explore' | 'execute' | 'plan' | 'review'
+  fullExecuteEnabled?: boolean
   messages: Array<{ role: string; content: string }>
   tools?: ToolDefinition[]
   workspacePath?: string
   artifacts?: ArtifactContext[]
   conversationId?: string  // Track which conversation this stream belongs to
+}
+
+type ModelToolSupport = 'tools_supported' | 'chat_only' | 'unknown'
+
+interface ModelToolCapability {
+  support: ModelToolSupport
+  label: 'Tools supported' | 'Chat only' | 'Tool support unknown'
+  source: 'explicit' | 'provider' | 'verified' | 'unknown'
+  reason: string
 }
 
 interface ArtifactContext {


### PR DESCRIPTION
## Summary

- Add right-click context menus for sidebar chat items and artifacts (rename, archive, transfer, log actions, artifact open/reference/reveal/delete)
- Add conversation log export to clipboard or Markdown file with message history, tool calls, artifacts, secret redaction, and content truncation
- Move Full Execute out of the mode rail into a dedicated composer toggle; streamline visible modes to Auto, Plan, Explore, Review
- Add provider-settings shortcut buttons in header and new-chat view; refresh canvas-toggle icon; remove extra top-pane spacing
- Add model tool-capability badges in model selector and a one-time decision prompt for tool-task messages sent to chat-only or unverified models
- Preserve manually entered Z.ai model IDs when live model discovery returns a different list

## Root Cause

Multiple open enhancement issues targeting context navigation, log access, execution-policy UX, and provider model-capability awareness.

## Fix

Each issue addressed as a focused feature addition: shared ContextMenu component wired into Sidebar and App; new conversationLog builder with IPC log handlers; BehaviorMode type split from AgentMode with fullExecuteEnabled threaded through stream IPC; Settings2 shortcut buttons added to Header and NewChatView; ModelToolCapabilityBadge and getLocalModelToolCapability modules integrated into ModelSelector and sendMessage flow.

Post-review fixes (second commit):
- ContextMenu closes only on Escape, not all keydown; items keyed by index
- verifyModelToolCapability live probe has a 10s fetch timeout
- Sidebar rename uses an inline input field (Enter/Escape/blur) instead of window.prompt
- Tool-capability warning ack key scoped to provider+model+support, not per-conversation
- database.ts loadDb initializes model_tool_capabilities to null for existing provider rows

## Changes

- `src/components/Common/ContextMenu.tsx` — new portal-based context menu component
- `src/components/Layout/Sidebar.tsx` — right-click menus; inline rename; conversation log collect actions
- `src/App.tsx` — app-level right-click menu; macOS titlebar overlay cleanup
- `src/lib/conversationLog.ts` — new conversation log builder with redaction and truncation
- `electron/ipc/logs.ts` — new IPC handlers for copy and save log actions
- `src/components/Chat/ChatInput.tsx` — Full Execute composer toggle; artifact reference event handler
- `src/lib/modes.ts` — BehaviorMode type; behaviorModes map; normalizeBehaviorMode helper
- `electron/lib/modeCapabilities.ts` — getEffectiveModeCapabilities accepting ExecutionPolicy
- `electron/ipc/ai.ts` — fullExecuteEnabled threaded through stream start, runtime update, and cleanup
- `electron/preload.ts` / `src/vite-env.d.ts` — expose logs API and updateStreamExecutionPolicy
- `src/components/Model/ModelToolCapabilityBadge.tsx` — new badge component
- `src/lib/modelToolCapabilities.ts` — capability detection and tool-task prompt heuristic
- `src/components/Model/ModelSelector.tsx` — capability badge per model option
- `src/stores/chat.ts` — fullExecuteEnabled state; tool-capability warning before send; setFullExecuteEnabled action
- `electron/ipc/providers.ts` / `electron/services/database.ts` / `src/stores/providers.ts` — modelToolCapabilities field wired through provider CRUD

## Issue

Fixes #147
Fixes #151
Fixes #152
Fixes #153
Fixes #155
Fixes #173
Fixes #174